### PR TITLE
Refactor animation editor launch and integrate with asset UI

### DIFF
--- a/ENGINE/ui/asset_info_ui.hpp
+++ b/ENGINE/ui/asset_info_ui.hpp
@@ -45,6 +45,7 @@ private:
     bool visible_ = false;
     std::shared_ptr<AssetInfo> info_{};
     std::unique_ptr<Button> b_close_;
+    std::unique_ptr<Button> b_config_anim_;
     // Widgets (owned)
     std::unique_ptr<Slider>   s_z_threshold_;
     std::unique_ptr<Slider>   s_min_same_type_;


### PR DESCRIPTION
## Summary
- Replace file browser in animation editor with direct info.json loading via command-line argument.
- Add "Configure Animations" button in asset info UI that launches the Python editor for the selected asset.

## Testing
- `python3 -m py_compile scripts/main.py`
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*


------
https://chatgpt.com/codex/tasks/task_e_68b7cdde6a30832f822aba37816dfb4e