### PR TITLE
Refactor: unify recursive asset helpers

### DIFF
--- a/ENGINE/asset/asset_utils.hpp
+++ b/ENGINE/asset/asset_utils.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Asset.hpp"
+
+// Recursively assign the rendering view to an asset and all of its children.
+inline void set_view_recursive(Asset* asset, view* v) {
+    if (!asset) return;
+    asset->set_view(v);
+    for (Asset* child : asset->children) {
+        set_view_recursive(child, v);
+    }
+}
+
+// Recursively assign the owning Assets manager to an asset hierarchy.
+inline void set_assets_owner_recursive(Asset* asset, Assets* owner) {
+    if (!asset) return;
+    asset->set_assets(owner);
+    for (Asset* child : asset->children) {
+        set_assets_owner_recursive(child, owner);
+    }
+}
+

--- a/ENGINE/asset/initialize_assets.cpp
+++ b/ENGINE/asset/initialize_assets.cpp
@@ -3,6 +3,7 @@
 #include "AssetsManager.hpp"
 #include "Asset.hpp"
 #include "asset_info.hpp"
+#include "asset_utils.hpp"
 #include "active_assets_manager.hpp"
 
 #include <algorithm>
@@ -10,27 +11,6 @@
 #include <stdexcept>
 #include <memory>
 
-namespace {
-// Recursively assign the rendering view to an asset and all its children.
-void set_view_recursive(Asset* asset, view* v) {
-    if (!asset) return;
-    asset->set_view(v);
-    for (Asset* child : asset->children) {
-        set_view_recursive(child, v);
-    }
-}
-
-// Recursively set the owning Assets manager for an asset hierarchy. This also
-// allows child assets to instantiate their custom controllers once the manager
-// becomes available.
-void set_assets_recursive(Asset* asset, Assets* owner) {
-    if (!asset) return;
-    asset->set_assets(owner);
-    for (Asset* child : asset->children) {
-        set_assets_recursive(child, owner);
-    }
-}
-} // namespace
 
 void InitializeAssets::initialize(Assets& assets,
                                   std::vector<Asset>&& loaded,
@@ -63,7 +43,7 @@ void InitializeAssets::initialize(Assets& assets,
         auto newAsset = std::make_unique<Asset>(std::move(a));
         Asset* raw = newAsset.get();
         set_view_recursive(raw, &assets.window);
-        set_assets_recursive(raw, &assets);
+        set_assets_owner_recursive(raw, &assets);
 
         assets.owned_assets.push_back(std::move(newAsset));
         assets.all.push_back(raw);

--- a/ENGINE/core/AssetsManager.cpp
+++ b/ENGINE/core/AssetsManager.cpp
@@ -5,6 +5,7 @@
 #include "find_current_room.hpp"   
 #include "asset/Asset.hpp"
 #include "asset/asset_info.hpp"
+#include "asset/asset_utils.hpp"
 #include "dev_mode/dev_mouse_controls.hpp"
 #include "utils/input.hpp"
 #include "render/scene_renderer.hpp"
@@ -15,25 +16,6 @@
 #include <iostream>
 #include <memory>
 
-namespace {
-// Ensure newly created assets and any children share the same view
-void set_view_recursive(Asset* asset, view* v) {
-    if (!asset) return;
-    asset->set_view(v);
-    for (Asset* child : asset->children) {
-        set_view_recursive(child, v);
-    }
-}
-
-// Ensure newly created assets and any children know their owning Assets manager
-void set_assets_owner_recursive(Asset* asset, Assets* owner) {
-    if (!asset) return;
-    asset->set_assets(owner);
-    for (Asset* child : asset->children) {
-        set_assets_owner_recursive(child, owner);
-    }
-}
-} // namespace
 
 Assets::Assets(std::vector<Asset>&& loaded,
                AssetLibrary& library,


### PR DESCRIPTION
## Summary
- move recursive view and owner setters into shared asset_utils header
- use shared helpers in AssetsManager and InitializeAssets to avoid duplicate definitions

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json" )*

------
https://chatgpt.com/codex/tasks/task_e_68baae764980832f9912b71fb9b75da1