### PR TITLE
Add centralized Asset deletion method

### DIFF
--- a/ENGINE/asset/Asset.cpp
+++ b/ENGINE/asset/Asset.cpp
@@ -269,8 +269,6 @@ SDL_Texture* Asset::get_current_frame() const {
  return nullptr;
 }
 
-void Asset::set_remove(){ remove = true; }
-
 void Asset::set_position(int x, int y) {
  pos_X = x;
  pos_Y = y;
@@ -479,3 +477,11 @@ bool  Asset::is_selected(){ return selected; }
 bool Asset::needs_removal() const { return remove; }
 
 void Asset::set_remove() { remove = true; }
+
+void Asset::delete_self() {
+    if (assets_) {
+        assets_->delete_asset(this);
+    } else {
+        delete this;
+    }
+}

--- a/ENGINE/asset/Asset.hpp
+++ b/ENGINE/asset/Asset.hpp
@@ -111,6 +111,7 @@ public:
  bool is_hidden();
   void set_remove();
   bool needs_removal() const;
+  void delete_self();
 
  void set_highlighted(bool state);
  bool is_highlighted();

--- a/ENGINE/core/AssetsManager.cpp
+++ b/ENGINE/core/AssetsManager.cpp
@@ -168,11 +168,7 @@ void Assets::update(const Input& input,
             if (up && up->needs_removal()) pending.push_back(up.get());
         }
         for (Asset* a : pending) {
-            auto it = std::find_if(owned_assets.begin(), owned_assets.end(),
-                                   [a](const std::unique_ptr<Asset>& p){ return p.get() == a; });
-            if (it != owned_assets.end()) {
-                owned_assets.erase(it); // triggers Asset::~Asset to unregister itself
-            }
+            delete_asset(a);
         }
     }
 }
@@ -348,6 +344,15 @@ Asset* Assets::spawn_asset(const std::string& name, int world_x, int world_y) {
               << "' at (" << world_x << ", " << world_y << ")\n";
 
     return newAsset;
+}
+
+void Assets::delete_asset(Asset* asset) {
+    if (!asset) return;
+    auto it = std::find_if(owned_assets.begin(), owned_assets.end(),
+                           [asset](const std::unique_ptr<Asset>& p){ return p.get() == asset; });
+    if (it != owned_assets.end()) {
+        owned_assets.erase(it); // triggers Asset::~Asset to unregister itself
+    }
 }
 
 

--- a/ENGINE/core/AssetsManager.hpp
+++ b/ENGINE/core/AssetsManager.hpp
@@ -103,6 +103,7 @@ Assets(std::vector<Asset>&& loaded,
 
     // Spawn API
     Asset* spawn_asset(const std::string& name, int world_x, int world_y);
+    void delete_asset(Asset* asset);
 
     // Overlay UIs
 public:

--- a/ENGINE/custom_controllers/Bomb_controller.cpp
+++ b/ENGINE/custom_controllers/Bomb_controller.cpp
@@ -66,7 +66,7 @@ void BombController::explosion_if_close(Asset* player) {
   
   if (self_->get_current_animation() == "explosion") {
     if (self_->is_current_animation_last_frame() && !self_->is_current_animation_looping()) {
-      self_->set_remove();
+      self_->delete_self();
     }
     return;
   }


### PR DESCRIPTION
## Summary
- Introduce `Asset::delete_self` to encapsulate asset cleanup and deallocation
- Add `Assets::delete_asset` and use it for all asset removals
- Replace manual removal logic and update Bomb controller to call the new API

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "glad")*

------
https://chatgpt.com/codex/tasks/task_e_68be2283e5fc832fb88b64df18ad9af4