### PR TITLE
feat: centralize asset deletion

### DIFF
--- a/ENGINE/asset/Asset.cpp
+++ b/ENGINE/asset/Asset.cpp
@@ -478,7 +478,7 @@ bool Asset::needs_removal() const { return remove; }
 
 void Asset::set_remove() { remove = true; }
 
-void Asset::delete_self() {
+void Asset::Delete() {
     if (assets_) {
         assets_->delete_asset(this);
     } else {

--- a/ENGINE/asset/Asset.hpp
+++ b/ENGINE/asset/Asset.hpp
@@ -111,7 +111,8 @@ public:
  bool is_hidden();
   void set_remove();
   bool needs_removal() const;
-  void delete_self();
+  // Remove this asset from its owner and destroy it.
+  void Delete();
 
  void set_highlighted(bool state);
  bool is_highlighted();

--- a/ENGINE/core/AssetsManager.cpp
+++ b/ENGINE/core/AssetsManager.cpp
@@ -168,7 +168,7 @@ void Assets::update(const Input& input,
             if (up && up->needs_removal()) pending.push_back(up.get());
         }
         for (Asset* a : pending) {
-            delete_asset(a);
+            if (a) a->Delete();
         }
     }
 }

--- a/ENGINE/custom_controllers/Bomb_controller.cpp
+++ b/ENGINE/custom_controllers/Bomb_controller.cpp
@@ -66,7 +66,7 @@ void BombController::explosion_if_close(Asset* player) {
   
   if (self_->get_current_animation() == "explosion") {
     if (self_->is_current_animation_last_frame() && !self_->is_current_animation_looping()) {
-      self_->delete_self();
+      self_->Delete();
     }
     return;
   }


### PR DESCRIPTION
## Summary
- add Asset::Delete to remove an asset from its owner and destroy it
- replace manual asset removal with calls to Asset::Delete
- use self_->Delete in BombController explosion handling

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glad")*

------
https://chatgpt.com/codex/tasks/task_e_68be26322300832faf1225553aec40bf