### PR TITLE
Optimize keyboard input tracking with fixed-size arrays

### DIFF
--- a/ENGINE/core/AssetsManager.cpp
+++ b/ENGINE/core/AssetsManager.cpp
@@ -150,7 +150,7 @@ void Assets::update(const Input& input,
     }
 
 
-    if (input.wasKeyPressed(SDLK_TAB)) {
+    if (input.wasScancodePressed(SDL_SCANCODE_TAB)) {
         toggle_asset_library();
     }
 

--- a/ENGINE/custom_controllers/Vibble_controller.cpp
+++ b/ENGINE/custom_controllers/Vibble_controller.cpp
@@ -31,10 +31,10 @@ void VibbleController::movement(const Input& input) {
    dx_ = dy_ = 0;
    if (!player_) return;
 
-   bool up    = input.isKeyDown(SDLK_w);
-   bool down  = input.isKeyDown(SDLK_s);
-   bool left  = input.isKeyDown(SDLK_a);
-   bool right = input.isKeyDown(SDLK_d);
+   bool up    = input.isScancodeDown(SDL_SCANCODE_W);
+   bool down  = input.isScancodeDown(SDL_SCANCODE_S);
+   bool left  = input.isScancodeDown(SDL_SCANCODE_A);
+   bool right = input.isScancodeDown(SDL_SCANCODE_D);
 
    int move_x = (right ? 1 : 0) - (left ? 1 : 0);
    int move_y = (down  ? 1 : 0) - (up    ? 1 : 0);
@@ -94,7 +94,7 @@ void VibbleController::handle_teleport(const Input& input) {
       return;
    }
 
-   if (input.wasKeyPressed(SDLK_SPACE) && !teleport_set_) {
+   if (input.wasScancodePressed(SDL_SCANCODE_SPACE) && !teleport_set_) {
       teleport_point_ = { player_->pos_X, player_->pos_Y };
       teleport_set_ = true;
 
@@ -118,7 +118,7 @@ void VibbleController::handle_teleport(const Input& input) {
       }
    }
 
-   if (input.wasKeyPressed(SDLK_q) && teleport_set_) {
+   if (input.wasScancodePressed(SDL_SCANCODE_Q) && teleport_set_) {
       // Teleport via Move helper using a single FrameMovement
       Animation::FrameMovement fm;
       fm.dx = teleport_point_.x - player_->pos_X;
@@ -140,11 +140,11 @@ void VibbleController::handle_teleport(const Input& input) {
 
 void VibbleController::update(const Input& input) {
    dx_ = dy_ = 0;
-   if (input.isKeyDown(SDLK_SPACE) || input.isKeyDown(SDLK_q)) {
+   if (input.isScancodeDown(SDL_SCANCODE_SPACE) || input.isScancodeDown(SDL_SCANCODE_Q)) {
       handle_teleport(input);
    }
    movement(input);
-   if (input.isKeyDown(SDLK_e)) {
+   if (input.isScancodeDown(SDL_SCANCODE_E)) {
       interaction();
    }
    if (player_) player_->update_animation_manager();

--- a/ENGINE/dev_mode/dev_mouse_controls.cpp
+++ b/ENGINE/dev_mode/dev_mouse_controls.cpp
@@ -32,7 +32,7 @@ void DevMouseControls::handle_mouse_input(const Input& input) {
         parallax_.setReference(player->pos_X, player->pos_Y);
     }
 
-    if (input.isKeyDown(SDLK_ESCAPE)) {
+    if (input.isScancodeDown(SDL_SCANCODE_ESCAPE)) {
         selected_assets.clear();
         highlighted_assets.clear();
         hovered_asset = nullptr;
@@ -171,7 +171,7 @@ void DevMouseControls::handle_click(const Input& input) {
 
     Asset* nearest = hovered_asset; 
     if (nearest) {
-        const bool ctrlHeld = input.isKeyDown(SDLK_LCTRL) || input.isKeyDown(SDLK_RCTRL);
+        const bool ctrlHeld = input.isScancodeDown(SDL_SCANCODE_LCTRL) || input.isScancodeDown(SDL_SCANCODE_RCTRL);
         auto it = std::find(selected_assets.begin(), selected_assets.end(), nearest);
 
         if (ctrlHeld) {
@@ -202,7 +202,7 @@ void DevMouseControls::handle_click(const Input& input) {
             last_click_asset_ = nearest;
         }
     } else {
-        const bool ctrlHeld = input.isKeyDown(SDLK_LCTRL) || input.isKeyDown(SDLK_RCTRL);
+        const bool ctrlHeld = input.isScancodeDown(SDL_SCANCODE_LCTRL) || input.isScancodeDown(SDL_SCANCODE_RCTRL);
         if (!ctrlHeld) {
             selected_assets.clear();
         }

--- a/ENGINE/utils/input.cpp
+++ b/ENGINE/utils/input.cpp
@@ -36,11 +36,10 @@ void Input::handleEvent(const SDL_Event& e) {
         break;
 
     case SDL_KEYDOWN:
-        // ignore key repeats for pressed edge state; key remains down
-        keys_down_.insert(e.key.keysym.sym);
+        keys_down_[e.key.keysym.scancode] = true;
         break;
     case SDL_KEYUP:
-        keys_down_.erase(e.key.keysym.sym);
+        keys_down_[e.key.keysym.scancode] = false;
         break;
     default:
         break;
@@ -57,15 +56,11 @@ void Input::update() {
     }
 
     // Keyboard transitions
-    keys_pressed_.clear();
-    keys_released_.clear();
-    for (const auto& k : keys_down_) {
-        if (prev_keys_down_.count(k) == 0) keys_pressed_.insert(k);
+    for (int i = 0; i < SDL_NUM_SCANCODES; ++i) {
+        keys_pressed_[i]  = (!prev_keys_down_[i] && keys_down_[i]);
+        keys_released_[i] = (prev_keys_down_[i] && !keys_down_[i]);
+        prev_keys_down_[i] = keys_down_[i];
     }
-    for (const auto& k : prev_keys_down_) {
-        if (keys_down_.count(k) == 0) keys_released_.insert(k);
-    }
-    prev_keys_down_ = keys_down_;
 
     // Reset per-frame deltas
     dx_ = dy_ = 0;

--- a/ENGINE/utils/input.hpp
+++ b/ENGINE/utils/input.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <SDL.h>
-#include <unordered_set>
+#include <array>
 
 class Input {
 public:
@@ -30,9 +30,22 @@ public:
     int getScrollY() const { return scrollY_; }
 
     // Keyboard queries
-    bool isKeyDown(SDL_Keycode key) const { return keys_down_.count(key) != 0; }
-    bool wasKeyPressed(SDL_Keycode key) const { return keys_pressed_.count(key) != 0; }
-    bool wasKeyReleased(SDL_Keycode key) const { return keys_released_.count(key) != 0; }
+    bool isKeyDown(SDL_Keycode key) const {
+        SDL_Scancode sc = SDL_GetScancodeFromKey(key);
+        return keys_down_[sc];
+    }
+    bool wasKeyPressed(SDL_Keycode key) const {
+        SDL_Scancode sc = SDL_GetScancodeFromKey(key);
+        return keys_pressed_[sc];
+    }
+    bool wasKeyReleased(SDL_Keycode key) const {
+        SDL_Scancode sc = SDL_GetScancodeFromKey(key);
+        return keys_released_[sc];
+    }
+
+    bool isScancodeDown(SDL_Scancode sc) const { return keys_down_[sc]; }
+    bool wasScancodePressed(SDL_Scancode sc) const { return keys_pressed_[sc]; }
+    bool wasScancodeReleased(SDL_Scancode sc) const { return keys_released_[sc]; }
 
 private:
     // Mouse state
@@ -46,8 +59,8 @@ private:
     int  scrollX_ = 0, scrollY_ = 0;
 
     // Keyboard state
-    std::unordered_set<SDL_Keycode> keys_down_;
-    std::unordered_set<SDL_Keycode> prev_keys_down_;
-    std::unordered_set<SDL_Keycode> keys_pressed_;
-    std::unordered_set<SDL_Keycode> keys_released_;
+    std::array<bool, SDL_NUM_SCANCODES> keys_down_{};
+    std::array<bool, SDL_NUM_SCANCODES> prev_keys_down_{};
+    std::array<bool, SDL_NUM_SCANCODES> keys_pressed_{};
+    std::array<bool, SDL_NUM_SCANCODES> keys_released_{};
 };


### PR DESCRIPTION
## Summary
- Replace unordered_set-based key tracking in `Input` with fixed-size arrays indexed by SDL scancodes
- Update keyboard query and transition logic to operate on arrays for faster per-frame processing
- Add direct scancode query helpers and switch controllers and asset manager to scancode constants

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by "glad")*

------
https://chatgpt.com/codex/tasks/task_e_68be4f64e934832f9306b9f6f1eb23c9