### PR TITLE
Link animations button to Python UI

### DIFF
--- a/ENGINE/dev_mode/asset_info_ui.cpp
+++ b/ENGINE/dev_mode/asset_info_ui.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdlib>
+#include <string>
 #include <stdexcept>
 #include <vector>
 
@@ -21,7 +22,6 @@
 #include "widgets.hpp"
 #include <cstdlib>
 #include "core/AssetsManager.hpp"
-#include "animations_editor_panel.hpp"
 
 AssetInfoUI::AssetInfoUI() {
     sections_.push_back(std::make_unique<Section_BasicInfo>());
@@ -51,7 +51,6 @@ AssetInfoUI::AssetInfoUI() {
     }
     // Configure Animations footer button
     configure_btn_ = std::make_unique<DMButton>("Configure Animations", &DMStyles::CreateButton(), 220, DMButton::height());
-    animations_panel_ = std::make_unique<AnimationsEditorPanel>();
 }
 
 AssetInfoUI::~AssetInfoUI() = default;
@@ -111,16 +110,10 @@ void AssetInfoUI::update(const Input& input, int screen_w, int screen_h) {
     }
 
     for (auto& s : sections_) s->update(input);
-
-    if (animations_panel_ && animations_panel_->is_open())
-        animations_panel_->update(input, screen_w, screen_h);
 }
 
 void AssetInfoUI::handle_event(const SDL_Event& e) {
     if (!visible_ || !info_) return;
-
-    if (animations_panel_ && animations_panel_->is_open() && animations_panel_->handle_event(e))
-        return;
 
     if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_ESCAPE) {
         close();
@@ -131,13 +124,11 @@ void AssetInfoUI::handle_event(const SDL_Event& e) {
         if (s->handle_event(e)) return;
     }
 
-    // Footer action: open C++ animations panel
+    // Footer action: launch Python animations UI
     if (configure_btn_ && configure_btn_->handle_event(e)) {
         if (e.type == SDL_MOUSEBUTTONUP && e.button.button == SDL_BUTTON_LEFT) {
-            if (animations_panel_) {
-                animations_panel_->set_asset_paths(info_->asset_dir_path(), info_->info_json_path());
-                animations_panel_->open();
-            }
+            std::string cmd = "python3 scripts/animation_ui.py \"" + info_->info_json_path() + "\" &";
+            std::system(cmd.c_str());
         }
         return;
     }
@@ -157,9 +148,6 @@ void AssetInfoUI::render(SDL_Renderer* r, int screen_w, int screen_h) const {
 
     // Render footer button
     if (configure_btn_) configure_btn_->render(r);
-
-    if (animations_panel_ && animations_panel_->is_open())
-        animations_panel_->render(r, screen_w, screen_h);
 
     last_renderer_ = r;
 }

--- a/ENGINE/dev_mode/asset_info_ui.hpp
+++ b/ENGINE/dev_mode/asset_info_ui.hpp
@@ -9,7 +9,6 @@ class AssetInfo;
 class Input;
 class Area;
 class Assets;
-class AnimationsEditorPanel;
 
 class AssetInfoUI {
 
@@ -45,5 +44,4 @@ class AssetInfoUI {
     mutable SDL_Rect panel_ {0,0,0,0};
     // Footer button: Configure Animations
     mutable std::unique_ptr<class DMButton> configure_btn_;
-    std::unique_ptr<AnimationsEditorPanel> animations_panel_;
 };


### PR DESCRIPTION
## Summary
- Launch Python animation_ui.py when the "Configure Animations" button is clicked in AssetInfoUI
- Remove unused C++ animations editor panel references

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "nlohmann_json")*

------
https://chatgpt.com/codex/tasks/task_e_68c79cdb2f00832f96caf3487a37040f