### PR TITLE
Optimize post-process surface reuse

### DIFF
--- a/ENGINE/render/scene_renderer.hpp
+++ b/ENGINE/render/scene_renderer.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <memory>
+#include <vector>
 #include <SDL.h>
 #include <nlohmann/json.hpp>
 #include "light_map.hpp"
@@ -16,6 +17,7 @@ class SceneRenderer {
 
 	public:
     SceneRenderer(SDL_Renderer* renderer, Assets* assets, int screen_width, int screen_height, const std::string& map_path);
+    ~SceneRenderer();
     void render();
     void apply_map_light_config(const nlohmann::json& data);
     SDL_Renderer* get_renderer() const;
@@ -43,5 +45,10 @@ class SceneRenderer {
     int            current_shading_group_ = 0;
     int            num_groups_ = 20;
     bool           debugging = false;
+
+    SDL_Surface*   postprocess_full_surface_ = nullptr;
+    SDL_Surface*   postprocess_small_surface_ = nullptr;
+    std::vector<Uint32> blur_row_buffer_;
+    std::vector<Uint32> blur_col_buffer_;
     
 };


### PR DESCRIPTION
## Summary
- reuse persistent SDL surfaces for the post-processing downscale/blur pass instead of allocating every frame
- cache horizontal/vertical blur buffers and add a renderer destructor that frees cached surfaces and the fullscreen light texture

## Testing
- not run (build configuration not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2251b2e08832f8150e76fd7c34e77