### PR TITLE
Revamp Windows bootstrap workflow

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -16,21 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          python-version: '3.12'
+          node-version: '18'
 
-      - name: Ensure Ninja is available
-        uses: seanmiddleditch/gha-setup-ninja@v1
-
-      - name: Install and build via run.bat
+      - name: Bootstrap toolchain and build
         shell: cmd
-        run: |
-          call run.bat --ci --skip-run --no-shortcut
+        run: npm run bootstrap:ci
 
       - name: Run ctest
         shell: cmd
-        run: |
-          cd build
-          ctest --build-config RelWithDebInfo --output-on-failure
+        run: npm run ctest

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "description": "Developer convenience scripts for the VIBBLE 2D Game Engine.",
   "private": true,
   "scripts": {
-    "configure": "cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=./ENGINE",
-    "build": "cmake --build build --config RelWithDebInfo",
-    "start": "run.bat",
-    "clean": "node -e \"const fs=require('fs');try{fs.rmSync('build',{recursive:true,force:true});}catch(e){}\""
+    "bootstrap": "node ./scripts/bootstrap.cjs",
+    "bootstrap:ci": "node ./scripts/bootstrap.cjs --ci --skip-run --no-shortcut",
+    "configure": "node ./scripts/bootstrap.cjs --configure-only",
+    "build": "node ./scripts/bootstrap.cjs --reuse-build --skip-run --no-shortcut",
+    "ctest": "node ./scripts/run-ctest.cjs",
+    "test": "npm run bootstrap:ci && npm run ctest",
+    "clean": "node -e \"const fs=require('fs');try{fs.rmSync('build',{recursive:true,force:true});}catch(e){}\"",
+    "start": "npm run bootstrap"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/scripts/bootstrap.cjs
+++ b/scripts/bootstrap.cjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+
+if (process.platform !== 'win32') {
+  console.error('[bootstrap] This project must be bootstrapped from Windows.');
+  process.exit(1);
+}
+
+const scriptPath = path.resolve(__dirname, '..', 'run.bat');
+const args = process.argv.slice(2);
+
+const command = [
+  `"${scriptPath}"`,
+  ...args.map((arg) => {
+    if (/\s|"/.test(arg)) {
+      return `"${arg.replace(/"/g, '\\"')}"`;
+    }
+    return arg;
+  })
+].join(' ');
+
+const child = spawn(command, {
+  stdio: 'inherit',
+  shell: true,
+  windowsVerbatimArguments: false
+});
+
+child.on('error', (error) => {
+  console.error(`[bootstrap] Failed to launch run.bat: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  process.exit(code === undefined ? 1 : code);
+});

--- a/scripts/run-ctest.cjs
+++ b/scripts/run-ctest.cjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+
+if (process.platform !== 'win32') {
+  console.error('[ctest] This helper is intended to run on Windows.');
+  process.exit(1);
+}
+
+const buildDir = path.resolve(__dirname, '..', 'build');
+if (!fs.existsSync(buildDir)) {
+  console.error('[ctest] Build directory not found. Run the bootstrap step first.');
+  process.exit(1);
+}
+
+const args = ['--build-config', 'RelWithDebInfo', '--output-on-failure'];
+const child = spawn('ctest', args, {
+  cwd: buildDir,
+  stdio: 'inherit',
+  shell: true
+});
+
+child.on('error', (error) => {
+  console.error(`[ctest] Failed to launch ctest: ${error.message}`);
+  process.exit(1);
+});
+
+child.on('exit', (code) => {
+  process.exit(code === undefined ? 1 : code);
+});


### PR DESCRIPTION
## Summary
- rewrite `run.bat` to validate prerequisites with winget, reuse vcpkg installations, and support CI-friendly switches such as build reuse and generator overrides
- add Node.js helpers and npm scripts that proxy the batch bootstrap to provide a consistent local and CI entry point, plus a ctest wrapper
- update the Windows GitHub Actions workflow to rely on the new npm bootstrap helper and run ctest while keeping vcpkg binary caching enabled

## Testing
- not run (Windows-only tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d2311b40cc832f89b4d99d733828c0