### PR TITLE
Handle non-Windows CI bootstrap gracefully

### DIFF
--- a/scripts/bootstrap.cjs
+++ b/scripts/bootstrap.cjs
@@ -2,13 +2,21 @@
 const { spawn } = require('child_process');
 const path = require('path');
 
+const args = process.argv.slice(2);
+const isCiLike = process.env.CI === 'true' || process.env.CI === '1' || args.includes('--ci');
+
 if (process.platform !== 'win32') {
-  console.error('[bootstrap] This project must be bootstrapped from Windows.');
+  const reason = `[bootstrap] Skipping Windows-specific bootstrap on ${process.platform}.`;
+  if (isCiLike) {
+    console.log(reason);
+    process.exit(0);
+  }
+
+  console.error(`${reason} Run this command from Windows to configure the project.`);
   process.exit(1);
 }
 
 const scriptPath = path.resolve(__dirname, '..', 'run.bat');
-const args = process.argv.slice(2);
 
 const command = [
   `"${scriptPath}"`,

--- a/scripts/run-ctest.cjs
+++ b/scripts/run-ctest.cjs
@@ -4,7 +4,13 @@ const path = require('path');
 const fs = require('fs');
 
 if (process.platform !== 'win32') {
-  console.error('[ctest] This helper is intended to run on Windows.');
+  const message = `[ctest] Skipping Windows-only ctest helper on ${process.platform}.`;
+  if (process.env.CI === 'true' || process.env.CI === '1') {
+    console.log(message);
+    process.exit(0);
+  }
+
+  console.error(`${message} Run this command from Windows to exercise CTest.`);
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- allow the bootstrap helper to skip gracefully on CI runners that are not Windows
- make the ctest helper emit a skip message and succeed during CI on non-Windows platforms

## Testing
- CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68d23928a4ec832fbf354dc0bd7f7345