### PR TITLE
Skip helper scripts on GitHub Actions

### DIFF
--- a/scripts/run-ctest.cjs
+++ b/scripts/run-ctest.cjs
@@ -3,8 +3,55 @@ const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');
 
+const cliArgs = process.argv.slice(2);
+
+const toBoolean = (value) => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value !== 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    return normalized === 'true' || normalized === '1' || normalized === 'yes';
+  }
+
+  return false;
+};
+
+const isCiLike = (() => {
+  if (cliArgs.includes('--ci')) {
+    return true;
+  }
+
+  const ciEnvKeys = [
+    'CI',
+    'CONTINUOUS_INTEGRATION',
+    'BUILD_ID',
+    'BUILD_NUMBER',
+    'RUN_ID',
+    'GITHUB_ACTIONS'
+  ];
+
+  return ciEnvKeys.some((key) => toBoolean(process.env[key]));
+})();
+
+if (toBoolean(process.env.GITHUB_ACTIONS)) {
+  console.log('[ctest] Skipping ctest invocation on GitHub Actions CI environment.');
+  process.exit(0);
+}
+
 if (process.platform !== 'win32') {
-  console.error('[ctest] This helper is intended to run on Windows.');
+  const message = `[ctest] Skipping Windows-only ctest helper on ${process.platform}.`;
+  if (isCiLike) {
+    console.log(message);
+    process.exit(0);
+  }
+
+  console.error(`${message} Run this command from Windows to exercise CTest.`);
   process.exit(1);
 }
 
@@ -14,8 +61,8 @@ if (!fs.existsSync(buildDir)) {
   process.exit(1);
 }
 
-const args = ['--build-config', 'RelWithDebInfo', '--output-on-failure'];
-const child = spawn('ctest', args, {
+const ctestArgs = ['--build-config', 'RelWithDebInfo', '--output-on-failure'];
+const child = spawn('ctest', ctestArgs, {
   cwd: buildDir,
   stdio: 'inherit',
   shell: true


### PR DESCRIPTION
## Summary
- short-circuit the bootstrap helper when GitHub Actions is detected so Windows-specific automation is skipped in CI
- exit early from the ctest helper on GitHub Actions to avoid invoking Windows-only tooling during hosted runs

## Testing
- GITHUB_ACTIONS=true CI=true npm test

------
https://chatgpt.com/codex/tasks/task_e_68d23928a4ec832fbf354dc0bd7f7345