### PR TITLE
Refine dev mode UI color palette

### DIFF
--- a/ENGINE/dev_mode/MapLightPanel.cpp
+++ b/ENGINE/dev_mode/MapLightPanel.cpp
@@ -482,7 +482,8 @@ void MapLightPanel::render_content(SDL_Renderer* r) const {
     SDL_SetRenderDrawColor(r, r_out, g_out, b_out, a_out);
     SDL_RenderFillRect(r, &swatch);
 
-    SDL_SetRenderDrawColor(r, 20, 20, 20, 220);
+    const SDL_Color border = DMStyles::Border();
+    SDL_SetRenderDrawColor(r, border.r, border.g, border.b, border.a);
     SDL_RenderDrawRect(r, &swatch);
 
     // A subtle label line above (optional): we won’t render text here to avoid font deps.

--- a/ENGINE/dev_mode/animation_utils.cpp
+++ b/ENGINE/dev_mode/animation_utils.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <climits>
 #include <cctype>
+#include "dm_styles.hpp"
 
 namespace fs = std::filesystem;
 
@@ -230,7 +231,8 @@ void MovementModal::render(SDL_Renderer* r) {
     Position pos{0,0};
     if(current_frame_ < (int)positions_.size())
         pos = positions_[current_frame_];
-    SDL_SetRenderDrawColor(r, 255, 0, 0, 255);
+    const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+    SDL_SetRenderDrawColor(r, accent.r, accent.g, accent.b, 255);
     SDL_RenderDrawLine(r, pos.first - 5, pos.second, pos.first + 5, pos.second);
     SDL_RenderDrawLine(r, pos.first, pos.second - 5, pos.first, pos.second + 5);
 }

--- a/ENGINE/dev_mode/animations_editor_panel.cpp
+++ b/ENGINE/dev_mode/animations_editor_panel.cpp
@@ -53,7 +53,8 @@ public:
         SDL_Rect dst{ rect_.x + (rect_.w - dw)/2, rect_.y + (rect_.h - dh)/2, dw, dh };
         SDL_RenderCopy(r, tex_, nullptr, &dst);
         // Border
-        SDL_SetRenderDrawColor(r, 90, 90, 90, 255);
+        const SDL_Color border = DMStyles::Border();
+        SDL_SetRenderDrawColor(r, border.r, border.g, border.b, border.a);
         SDL_RenderDrawRect(r, &rect_);
     }
     void invalidate() { last_path_.clear(); }

--- a/ENGINE/dev_mode/asset_info_ui.cpp
+++ b/ENGINE/dev_mode/asset_info_ui.cpp
@@ -485,7 +485,8 @@ void AssetInfoUI::render(SDL_Renderer* r, int screen_w, int screen_h) const {
     if (pulse_frames_ > 0) {
         Uint8 alpha = static_cast<Uint8>(std::clamp(pulse_frames_ * 12, 0, 180));
         SDL_Rect header_rect{panel_.x, panel_.y, panel_.w, DMButton::height()};
-        SDL_SetRenderDrawColor(r, 255, 220, 64, alpha);
+        const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+        SDL_SetRenderDrawColor(r, accent.r, accent.g, accent.b, alpha);
         SDL_RenderFillRect(r, &header_rect);
     }
 
@@ -584,7 +585,8 @@ void AssetInfoUI::render_world_overlay(SDL_Renderer* r, const camera& cam) const
     if (!lighting_section_ || !lighting_section_->is_expanded() || !lighting_section_->shading_enabled() || !target_asset_) return;
     const LightSource& light = lighting_section_->shading_light();
     if (light.x_radius <= 0 && light.y_radius <= 0) return;
-    SDL_SetRenderDrawColor(r, 255, 255, 0, 255);
+    const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+    SDL_SetRenderDrawColor(r, accent.r, accent.g, accent.b, 255);
     const bool flipped = target_asset_->flipped;
     const int base_offset_x = flipped ? -light.offset_x : light.offset_x;
     for (int deg = 0; deg < 360; ++deg) {

--- a/ENGINE/dev_mode/asset_library_ui.cpp
+++ b/ENGINE/dev_mode/asset_library_ui.cpp
@@ -23,8 +23,8 @@
 #include <cstdint>   // for std::uintptr_t
 
 namespace {
-    const SDL_Color kTileBG  = dm::rgba(40,40,40,180);
-    const SDL_Color kTileHL  = dm::rgba(200,200,60,100);
+    const SDL_Color kTileBG  = dm::rgba(24, 36, 56, 210);
+    const SDL_Color kTileHL  = dm::rgba(59, 130, 246, 110);
     const SDL_Color kTileBd  = DMStyles::Border();
     namespace fs = std::filesystem;
 
@@ -439,15 +439,18 @@ void AssetLibraryUI::render(SDL_Renderer* r, int screen_w, int screen_h) const {
     if (showing_create_popup_) {
         SDL_Rect box{ screen_w/2 - 150, screen_h/2 - 40, 300, 80 };
         SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
-        SDL_SetRenderDrawColor(r, 20,20,20,220);
+        const SDL_Color panel_bg = DMStyles::PanelBG();
+        SDL_SetRenderDrawColor(r, panel_bg.r, panel_bg.g, panel_bg.b, panel_bg.a);
         SDL_RenderFillRect(r, &box);
-        SDL_SetRenderDrawColor(r, 255,255,255,255);
+        const SDL_Color panel_border = DMStyles::Border();
+        SDL_SetRenderDrawColor(r, panel_border.r, panel_border.g, panel_border.b, panel_border.a);
         SDL_RenderDrawRect(r, &box);
 
         SDL_Rect input_rect{ box.x + 8, box.y + 8, box.w - 16, box.h - 16 };
-        SDL_SetRenderDrawColor(r, 35,35,35,230);
+        const DMTextBoxStyle& textbox = DMStyles::TextBox();
+        SDL_SetRenderDrawColor(r, textbox.bg.r, textbox.bg.g, textbox.bg.b, textbox.bg.a);
         SDL_RenderFillRect(r, &input_rect);
-        SDL_SetRenderDrawColor(r, 90,90,90,255);
+        SDL_SetRenderDrawColor(r, textbox.border.r, textbox.border.g, textbox.border.b, textbox.border.a);
         SDL_RenderDrawRect(r, &input_rect);
 
         const int text_padding = 12;
@@ -455,8 +458,8 @@ void AssetLibraryUI::render(SDL_Renderer* r, int screen_w, int screen_h) const {
         if (font) {
             std::string display = new_asset_name_.empty() ? "Enter asset name..." : new_asset_name_;
             SDL_Color color = new_asset_name_.empty()
-                                ? SDL_Color{180, 180, 180, 255}
-                                : SDL_Color{255, 255, 255, 255};
+                                ? textbox.label.color
+                                : textbox.text;
             int available_w = input_rect.w - 2 * text_padding;
             int tw = 0;
             int th = 0;

--- a/ENGINE/dev_mode/asset_sections/Section_BasicInfo.hpp
+++ b/ENGINE/dev_mode/asset_sections/Section_BasicInfo.hpp
@@ -7,6 +7,7 @@
 #include "render/camera.hpp"
 #include "widgets.hpp"
 #include "dev_mode/asset_info_sections.hpp"
+#include "dm_styles.hpp"
 #include <algorithm>
 #include <cmath>
 #include <memory>
@@ -188,7 +189,8 @@ inline void Section_BasicInfo::render_world_overlay(SDL_Renderer* r,
     SDL_Point z_screen = cam.map_to_screen(SDL_Point{target->pos.x, z_world_y});
 
     SDL_SetRenderDrawBlendMode(r, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor(r, 255, 0, 0, 200);
+    const SDL_Color accent = DMStyles::DeleteButton().hover_bg;
+    SDL_SetRenderDrawColor(r, accent.r, accent.g, accent.b, 200);
     SDL_RenderDrawLine(r, bounds.x, z_screen.y, bounds.x + bounds.w, z_screen.y);
 }
 

--- a/ENGINE/dev_mode/dm_styles.cpp
+++ b/ENGINE/dev_mode/dm_styles.cpp
@@ -1,104 +1,163 @@
 #include "dm_styles.hpp"
 
+namespace {
+const SDL_Color kTextPrimary       = dm::rgba(226, 232, 240, 255);
+const SDL_Color kTextSecondary     = dm::rgba(203, 213, 225, 255);
+
+const SDL_Color kPanelBackground   = dm::rgba(15, 23, 42, 235);
+const SDL_Color kPanelHeader       = dm::rgba(30, 41, 59, 240);
+const SDL_Color kPanelBorder       = dm::rgba(71, 85, 105, 255);
+
+const SDL_Color kHeaderBg          = dm::rgba(30, 41, 59, 235);
+const SDL_Color kHeaderHover       = dm::rgba(46, 64, 94, 245);
+const SDL_Color kHeaderPress       = dm::rgba(24, 34, 53, 245);
+const SDL_Color kHeaderText        = kTextPrimary;
+
+const SDL_Color kAccentBg          = dm::rgba(37, 99, 235, 235);
+const SDL_Color kAccentHover       = dm::rgba(59, 130, 246, 245);
+const SDL_Color kAccentPress       = dm::rgba(29, 78, 216, 235);
+const SDL_Color kAccentBorder      = dm::rgba(30, 64, 175, 255);
+const SDL_Color kAccentText        = dm::rgba(240, 249, 255, 255);
+
+const SDL_Color kListBg            = dm::rgba(20, 30, 49, 210);
+const SDL_Color kListHover         = dm::rgba(31, 45, 70, 230);
+const SDL_Color kListPress         = dm::rgba(41, 56, 85, 240);
+const SDL_Color kListBorder        = dm::rgba(52, 70, 105, 255);
+const SDL_Color kListText          = dm::rgba(215, 224, 244, 255);
+
+const SDL_Color kCreateBg          = dm::rgba(34, 139, 116, 230);
+const SDL_Color kCreateHover       = dm::rgba(52, 167, 140, 240);
+const SDL_Color kCreatePress       = dm::rgba(28, 117, 97, 230);
+const SDL_Color kCreateBorder      = dm::rgba(30, 120, 100, 255);
+const SDL_Color kCreateText        = dm::rgba(230, 252, 244, 255);
+
+const SDL_Color kDeleteBg          = dm::rgba(185, 28, 28, 235);
+const SDL_Color kDeleteHover       = dm::rgba(220, 38, 38, 245);
+const SDL_Color kDeletePress       = dm::rgba(153, 27, 27, 235);
+const SDL_Color kDeleteBorder      = dm::rgba(127, 29, 29, 255);
+const SDL_Color kDeleteText        = dm::rgba(254, 226, 226, 255);
+
+const SDL_Color kTextboxBg         = dm::rgba(13, 23, 38, 235);
+const SDL_Color kTextboxBorder     = dm::rgba(48, 64, 96, 255);
+const SDL_Color kTextboxBorderHot  = dm::rgba(73, 103, 151, 255);
+const SDL_Color kTextboxText       = kTextPrimary;
+
+const SDL_Color kCheckboxBg        = dm::rgba(20, 32, 52, 235);
+const SDL_Color kCheckboxBorder    = dm::rgba(57, 81, 123, 255);
+const SDL_Color kCheckboxCheck     = dm::rgba(59, 130, 246, 255);
+
+const SDL_Color kSliderTrack       = dm::rgba(21, 30, 50, 220);
+const SDL_Color kSliderFill        = dm::rgba(59, 130, 246, 240);
+const SDL_Color kSliderKnob        = dm::rgba(226, 232, 240, 255);
+const SDL_Color kSliderKnobHover   = dm::rgba(186, 230, 253, 255);
+const SDL_Color kSliderKnobBorder  = dm::rgba(59, 130, 246, 255);
+const SDL_Color kSliderKnobBorderHover = dm::rgba(96, 165, 250, 255);
+} // namespace
+
 const DMLabelStyle &DMStyles::Label() {
-  static const DMLabelStyle s{dm::FONT_PATH, 16, dm::rgba(230, 230, 230, 255)};
+  static const DMLabelStyle s{dm::FONT_PATH, 16, kTextPrimary};
   return s;
 }
 
 const DMButtonStyle &DMStyles::HeaderButton() {
   static const DMButtonStyle s{
-      {dm::FONT_PATH, 18, dm::rgba(220, 220, 220, 255)},
-      dm::rgba(0, 0, 0, 0),
-      dm::rgba(40, 40, 40, 60),
-      dm::rgba(60, 60, 60, 80),
-      dm::rgba(0, 0, 0, 0),
-      dm::rgba(220, 220, 220, 255)};
+      {dm::FONT_PATH, 18, kHeaderText},
+      kHeaderBg,
+      kHeaderHover,
+      kHeaderPress,
+      kPanelBorder,
+      kHeaderText};
   return s;
 }
 
 const DMButtonStyle &DMStyles::AccentButton() {
   static const DMButtonStyle s{
-      {dm::FONT_PATH, 18, dm::rgba(235, 240, 255, 255)},
-      dm::rgba(40, 80, 150, 140),
-      dm::rgba(60, 110, 190, 180),
-      dm::rgba(80, 130, 210, 220),
-      dm::rgba(30, 70, 130, 200),
-      dm::rgba(235, 240, 255, 255)};
+      {dm::FONT_PATH, 18, kAccentText},
+      kAccentBg,
+      kAccentHover,
+      kAccentPress,
+      kAccentBorder,
+      kAccentText};
   return s;
 }
 
 const DMButtonStyle &DMStyles::ListButton() {
   static const DMButtonStyle s{
-      {dm::FONT_PATH, 16, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(60, 60, 60, 80),
-      dm::rgba(90, 90, 90, 120),
-      dm::rgba(110, 110, 110, 160),
-      dm::rgba(90, 90, 90, 255),
-      dm::rgba(230, 230, 230, 255)};
+      {dm::FONT_PATH, 16, kListText},
+      kListBg,
+      kListHover,
+      kListPress,
+      kListBorder,
+      kListText};
   return s;
 }
 
 const DMButtonStyle &DMStyles::CreateButton() {
   static const DMButtonStyle s{
-      {dm::FONT_PATH, 16, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(70, 70, 70, 100),
-      dm::rgba(110, 110, 110, 140),
-      dm::rgba(130, 130, 130, 180),
-      dm::rgba(90, 90, 90, 255),
-      dm::rgba(230, 230, 230, 255)};
+      {dm::FONT_PATH, 16, kCreateText},
+      kCreateBg,
+      kCreateHover,
+      kCreatePress,
+      kCreateBorder,
+      kCreateText};
   return s;
 }
 
 const DMButtonStyle &DMStyles::DeleteButton() {
   static const DMButtonStyle s{
-      {dm::FONT_PATH, 16, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(120, 40, 40, 120),
-      dm::rgba(150, 60, 60, 160),
-      dm::rgba(180, 80, 80, 200),
-      dm::rgba(90, 40, 40, 255),
-      dm::rgba(230, 230, 230, 255)};
+      {dm::FONT_PATH, 16, kDeleteText},
+      kDeleteBg,
+      kDeleteHover,
+      kDeletePress,
+      kDeleteBorder,
+      kDeleteText};
   return s;
 }
 
 const DMTextBoxStyle &DMStyles::TextBox() {
   static const DMTextBoxStyle s{
-      {dm::FONT_PATH, 14, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(50, 50, 50, 100),
-      dm::rgba(90, 90, 90, 255),
-      dm::rgba(130, 130, 130, 255),
-      dm::rgba(240, 240, 240, 255)};
+      {dm::FONT_PATH, 14, kTextSecondary},
+      kTextboxBg,
+      kTextboxBorder,
+      kTextboxBorderHot,
+      kTextboxText};
   return s;
 }
 
 const DMCheckboxStyle &DMStyles::Checkbox() {
   static const DMCheckboxStyle s{
-      {dm::FONT_PATH, 14, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(40, 40, 40, 200),
-      dm::rgba(220, 220, 220, 255),
-      dm::rgba(90, 90, 90, 255)};
+      {dm::FONT_PATH, 14, kTextSecondary},
+      kCheckboxBg,
+      kCheckboxCheck,
+      kCheckboxBorder};
   return s;
 }
 
 const DMSliderStyle &DMStyles::Slider() {
   static const DMSliderStyle s{
-      {dm::FONT_PATH, 14, dm::rgba(230, 230, 230, 255)},
-      {dm::FONT_PATH, 14, dm::rgba(230, 230, 230, 255)},
-      dm::rgba(60, 60, 60, 100),
-      dm::rgba(140, 140, 140, 180),
-      dm::rgba(180, 180, 180, 255),
-      dm::rgba(210, 210, 210, 255),
-      dm::rgba(90, 90, 90, 255),
-      dm::rgba(120, 120, 120, 255)};
+      {dm::FONT_PATH, 14, kTextSecondary},
+      {dm::FONT_PATH, 14, kTextPrimary},
+      kSliderTrack,
+      kSliderFill,
+      kSliderKnob,
+      kSliderKnobHover,
+      kSliderKnobBorder,
+      kSliderKnobBorderHover};
   return s;
 }
 
 const SDL_Color &DMStyles::PanelBG() {
-  static const SDL_Color c = dm::rgba(10, 10, 10, 200);
+  static const SDL_Color c = kPanelBackground;
+  return c;
+}
+
+const SDL_Color &DMStyles::PanelHeader() {
+  static const SDL_Color c = kPanelHeader;
   return c;
 }
 
 const SDL_Color &DMStyles::Border() {
-  static const SDL_Color c = dm::rgba(90, 90, 90, 255);
+  static const SDL_Color c = kPanelBorder;
   return c;
 }
 

--- a/ENGINE/dev_mode/dm_styles.hpp
+++ b/ENGINE/dev_mode/dm_styles.hpp
@@ -72,6 +72,7 @@ public:
   static const DMCheckboxStyle &Checkbox();
   static const DMSliderStyle &Slider();
   static const SDL_Color &PanelBG();
+  static const SDL_Color &PanelHeader();
   static const SDL_Color &Border();
 };
 

--- a/ENGINE/dev_mode/full_screen_collapsible.cpp
+++ b/ENGINE/dev_mode/full_screen_collapsible.cpp
@@ -200,7 +200,7 @@ bool FullScreenCollapsible::handle_event(const SDL_Event& e) {
 void FullScreenCollapsible::render(SDL_Renderer* renderer) const {
     if (!visible_ || !renderer) return;
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    const SDL_Color header_bg = DMStyles::PanelBG();
+    const SDL_Color header_bg = DMStyles::PanelHeader();
     SDL_SetRenderDrawColor(renderer, header_bg.r, header_bg.g, header_bg.b, 240);
     SDL_RenderFillRect(renderer, &header_rect_);
     const SDL_Color border = DMStyles::Border();
@@ -209,7 +209,8 @@ void FullScreenCollapsible::render(SDL_Renderer* renderer) const {
 
     if (expanded_) {
         SDL_Rect content = content_rect_;
-        SDL_SetRenderDrawColor(renderer, header_bg.r, header_bg.g, header_bg.b, 220);
+        const SDL_Color content_bg = DMStyles::PanelBG();
+        SDL_SetRenderDrawColor(renderer, content_bg.r, content_bg.g, content_bg.b, 220);
         SDL_RenderFillRect(renderer, &content);
         SDL_SetRenderDrawColor(renderer, border.r, border.g, border.b, border.a);
         SDL_RenderDrawRect(renderer, &content);
@@ -226,7 +227,8 @@ void FullScreenCollapsible::render(SDL_Renderer* renderer) const {
         if (!btn.widget) continue;
         if (btn.active) {
             SDL_Rect rect = btn.widget->rect();
-            SDL_SetRenderDrawColor(renderer, 120, 160, 255, 80);
+            const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+            SDL_SetRenderDrawColor(renderer, accent.r, accent.g, accent.b, 96);
             SDL_RenderFillRect(renderer, &rect);
         }
         btn.widget->render(renderer);

--- a/ENGINE/dev_mode/map_layers_panel.cpp
+++ b/ENGINE/dev_mode/map_layers_panel.cpp
@@ -461,9 +461,11 @@ bool MapLayersPanel::LayerCanvasWidget::handle_event(const SDL_Event& e) {
 void MapLayersPanel::LayerCanvasWidget::render(SDL_Renderer* renderer) const {
     if (!renderer) return;
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor(renderer, 18, 18, 18, 200);
+    const SDL_Color bg = DMStyles::PanelBG();
+    SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
     SDL_RenderFillRect(renderer, &rect_);
-    SDL_SetRenderDrawColor(renderer, 64, 64, 64, 255);
+    const SDL_Color border = DMStyles::Border();
+    SDL_SetRenderDrawColor(renderer, border.r, border.g, border.b, border.a);
     SDL_RenderDrawRect(renderer, &rect_);
     if (!owner_ || circles_.empty()) return;
 
@@ -532,7 +534,8 @@ void MapLayersPanel::LayerCanvasWidget::render(SDL_Renderer* renderer) const {
                 SDL_Rect room_rect{ center_pt.x - half_w, center_pt.y - half_h, half_w * 2, half_h * 2 };
                 SDL_RenderDrawRect(renderer, &room_rect);
             }
-            SDL_SetRenderDrawColor(renderer, 255, 255, 255, 60);
+            const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+            SDL_SetRenderDrawColor(renderer, accent.r, accent.g, accent.b, 120);
             SDL_RenderDrawPoint(renderer, center_pt.x, center_pt.y);
 
             double extent_units = node->is_circle ? node->width * 0.5
@@ -622,9 +625,11 @@ void MapLayersPanel::PanelSidebarWidget::set_dirty(bool dirty) {
 void MapLayersPanel::PanelSidebarWidget::render(SDL_Renderer* renderer) const {
     if (!renderer) return;
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor(renderer, 14, 14, 14, 220);
+    const SDL_Color bg = DMStyles::PanelBG();
+    SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
     SDL_RenderFillRect(renderer, &rect_);
-    SDL_SetRenderDrawColor(renderer, 64, 64, 64, 255);
+    const SDL_Color border = DMStyles::Border();
+    SDL_SetRenderDrawColor(renderer, border.r, border.g, border.b, border.a);
     SDL_RenderDrawRect(renderer, &rect_);
     if (add_button_) add_button_->render(renderer);
     if (new_room_button_) new_room_button_->render(renderer);
@@ -1114,9 +1119,11 @@ void MapLayersPanel::RoomCandidateWidget::render(SDL_Renderer* renderer) const {
     if (!renderer || !candidate_) return;
     SDL_Rect bg = rect_;
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor(renderer, 28, 28, 28, 220);
+    const SDL_Color row_bg = DMStyles::PanelHeader();
+    SDL_SetRenderDrawColor(renderer, row_bg.r, row_bg.g, row_bg.b, row_bg.a);
     SDL_RenderFillRect(renderer, &bg);
-    SDL_SetRenderDrawColor(renderer, 80, 80, 80, 255);
+    const SDL_Color border = DMStyles::Border();
+    SDL_SetRenderDrawColor(renderer, border.r, border.g, border.b, border.a);
     SDL_RenderDrawRect(renderer, &bg);
 
     const DMLabelStyle label = DMStyles::Label();
@@ -1126,9 +1133,10 @@ void MapLayersPanel::RoomCandidateWidget::render(SDL_Renderer* renderer) const {
     if (delete_button_) delete_button_->render(renderer);
 
     for (const auto& chip : child_chips_) {
-        SDL_SetRenderDrawColor(renderer, 36, 36, 36, 240);
+        const DMButtonStyle& chip_style = DMStyles::ListButton();
+        SDL_SetRenderDrawColor(renderer, chip_style.bg.r, chip_style.bg.g, chip_style.bg.b, chip_style.bg.a);
         SDL_RenderFillRect(renderer, &chip.rect);
-        SDL_SetRenderDrawColor(renderer, 90, 90, 90, 255);
+        SDL_SetRenderDrawColor(renderer, chip_style.border.r, chip_style.border.g, chip_style.border.b, chip_style.border.a);
         SDL_RenderDrawRect(renderer, &chip.rect);
         draw_text(renderer, chip.name, chip.rect.x + 6, chip.rect.y + (chip.rect.h - label.font_size) / 2, label);
         if (chip.remove_button) chip.remove_button->render(renderer);

--- a/ENGINE/dev_mode/room_editor.cpp
+++ b/ENGINE/dev_mode/room_editor.cpp
@@ -13,6 +13,7 @@
 #include "dev_mode/full_screen_collapsible.hpp"
 #include "dev_mode/room_configurator.hpp"
 #include "dev_mode/widgets.hpp"
+#include "dm_styles.hpp"
 #include "render/camera.hpp"
 #include "room/room.hpp"
 #include "spawn/asset_spawn_planner.hpp"
@@ -419,7 +420,8 @@ void RoomEditor::render_overlays(SDL_Renderer* renderer) {
             int radius_px = static_cast<int>(std::lround(overlay->radius * inv_scale));
             radius_px = std::max(1, radius_px);
             SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-            SDL_SetRenderDrawColor(renderer, 32, 200, 255, 210);
+            const SDL_Color accent = DMStyles::AccentButton().hover_bg;
+            SDL_SetRenderDrawColor(renderer, accent.r, accent.g, accent.b, 210);
             const int segments = std::clamp(radius_px * 4, 64, 720);
             for (int i = 0; i < segments; ++i) {
                 double angle = (static_cast<double>(i) / static_cast<double>(segments)) * 2.0 * M_PI;

--- a/ENGINE/dev_mode/room_selector_popup.cpp
+++ b/ENGINE/dev_mode/room_selector_popup.cpp
@@ -165,9 +165,11 @@ void RoomSelectorPopup::render(SDL_Renderer* renderer) const {
     if (!visible_ || !renderer) return;
     ensure_geometry();
     SDL_SetRenderDrawBlendMode(renderer, SDL_BLENDMODE_BLEND);
-    SDL_SetRenderDrawColor(renderer, 24, 24, 24, 240);
+    const SDL_Color bg = DMStyles::PanelBG();
+    SDL_SetRenderDrawColor(renderer, bg.r, bg.g, bg.b, bg.a);
     SDL_RenderFillRect(renderer, &rect_);
-    SDL_SetRenderDrawColor(renderer, 90, 90, 90, 255);
+    const SDL_Color border = DMStyles::Border();
+    SDL_SetRenderDrawColor(renderer, border.r, border.g, border.b, border.a);
     SDL_RenderDrawRect(renderer, &rect_);
 
     SDL_Rect prev_clip{};


### PR DESCRIPTION
## Summary
- refresh dev-mode styling with a cohesive palette and a dedicated panel header color for buttons and windows
- apply the new scheme across modal frames, map layer tooling, popups, and other widgets for consistent highlights
- align overlay indicators and utility popups with purposeful accent or destructive hues

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d23be87950832fb42256f8b153697e