### PR TITLE
Unify animation movement on 3D world intents

### DIFF
--- a/ENGINE/animation_update/animation_runtime.cpp
+++ b/ENGINE/animation_update/animation_runtime.cpp
@@ -1,4 +1,4 @@
-﻿#include "animation_runtime.hpp"
+#include "animation_runtime.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -162,18 +162,18 @@ void AnimationRuntime::apply_pending_move() {
     const auto req = planner_iface_->consume_move_request();
     const int  resolution = effective_grid_resolution(std::nullopt);
     const SDL_Point from{ self_->pos.x, self_->pos.y };
-    SDL_Point world_delta = convert_delta_to_world(req.delta, resolution);
-    const SDL_Point to{ from.x + world_delta.x, from.y + world_delta.y };
+    axis::WorldPos world_delta = convert_delta_to_world(req.delta, resolution);
+    const SDL_Point to{ from.x + world_delta.x, from.y + world_delta.z };
 
     SDL_Point final_position = from;
-    if (world_delta.x != 0 || world_delta.y != 0) {
+    if (world_delta.x != 0 || world_delta.z != 0) {
         if (!path_blocked(from, to, self_, nullptr)) {
             final_position = to;
         } else {
-            const int steps = std::max(std::abs(world_delta.x), std::abs(world_delta.y));
+            const int steps = std::max(std::abs(world_delta.x), std::abs(world_delta.z));
             if (steps > 0) {
                 const double step_x = static_cast<double>(world_delta.x) / static_cast<double>(steps);
-                const double step_y = static_cast<double>(world_delta.y) / static_cast<double>(steps);
+                const double step_y = static_cast<double>(world_delta.z) / static_cast<double>(steps);
                 double       accum_x = static_cast<double>(from.x);
                 double       accum_y = static_cast<double>(from.y);
                 SDL_Point    current = from;
@@ -191,17 +191,14 @@ void AnimationRuntime::apply_pending_move() {
     }
 
     if (final_position.x != self_->pos.x || final_position.y != self_->pos.y) {
-        self_->pos = final_position;
-        if (req.resort_z) {
-            refresh_z_index();
-        }
+        apply_resolved_world_position(axis::from_xz(final_position, req.delta.y), req.resort_z);
         suppress_root_motion_frames_ = std::max(2, suppress_root_motion_frames_);
         if (planner_iface_) {
             planner_iface_->clear_movement_plan();
         }
     }
 
-    planner_iface_->final_dest = self_->pos;
+    planner_iface_->final_dest = axis::from_xz(self_->pos, req.delta.y);
 
     const std::string resolved = resolve_animation(*self_, req.animation_id);
     if (self_->current_animation != resolved) {
@@ -1140,7 +1137,8 @@ void AnimationRuntime::mark_progress_toward_checkpoints() {
     const int visited_thresh = planner_iface_->visited_thresh_;
     const int visited_sq     = visited_thresh * visited_thresh;
     while (next_checkpoint_index_ < planner_iface_->plan_.sanitized_checkpoints.size()) {
-        const SDL_Point target  = planner_iface_->plan_.sanitized_checkpoints[next_checkpoint_index_];
+        const axis::WorldPos target_world = planner_iface_->plan_.sanitized_checkpoints[next_checkpoint_index_];
+        const SDL_Point target = axis::project_xz(target_world);
         const int       dist_sq = animation_update::detail::distance_sq(self_->pos, target);
         bool reached = false;
         if (visited_thresh == 0) {
@@ -1160,7 +1158,8 @@ bool AnimationRuntime::adjust_next_checkpoint(const std::vector<const Asset*>& b
         return false;
     }
     mark_progress_toward_checkpoints();
-    SDL_Point target = (next_checkpoint_index_ < planner_iface_->plan_.sanitized_checkpoints.size()) ? planner_iface_->plan_.sanitized_checkpoints[next_checkpoint_index_] : planner_iface_->final_dest;
+    axis::WorldPos target_world = (next_checkpoint_index_ < planner_iface_->plan_.sanitized_checkpoints.size()) ? planner_iface_->plan_.sanitized_checkpoints[next_checkpoint_index_] : planner_iface_->final_dest;
+    SDL_Point target = axis::project_xz(target_world);
     SDL_Point bottom_target = animation_update::detail::bottom_middle_for(*self_, target);
     SDL_Point push{0, 0};
     std::vector<const Asset*> influencing_neighbors;
@@ -1223,14 +1222,14 @@ bool AnimationRuntime::adjust_next_checkpoint(const std::vector<const Asset*>& b
         add_direction(directions, SDL_Point{ primary.y, -primary.x });
         add_direction(directions, SDL_Point{ -primary.y, primary.x });
     }
-    std::vector<SDL_Point> tail;
+    std::vector<axis::WorldPos> tail;
     for (std::size_t i = next_checkpoint_index_ + 1; i < planner_iface_->plan_.sanitized_checkpoints.size(); ++i) {
         tail.push_back(planner_iface_->plan_.sanitized_checkpoints[i]);
     }
-    if (tail.empty() || !same_point(tail.back(), planner_iface_->final_dest)) {
+    if (tail.empty() || !same_point(axis::project_xz(tail.back()), axis::project_xz(planner_iface_->final_dest))) {
         tail.push_back(planner_iface_->final_dest);
     }
-    auto try_plan_with_targets = [&](const std::vector<SDL_Point>& targets) {
+    auto try_plan_with_targets = [&](const std::vector<axis::WorldPos>& targets) {
         if (targets.empty()) return false;
         auto sanitized = sanitizer_.sanitize(*self_, targets, planner_iface_->visited_thresh_);
         if (sanitized.empty()) return false;
@@ -1254,10 +1253,10 @@ bool AnimationRuntime::adjust_next_checkpoint(const std::vector<const Asset*>& b
             SDL_Point bottom_next = animation_update::detail::bottom_middle_for(*self_, next);
             if (point_in_impassable(bottom_next, self_)) break;
             candidate = next;
-            std::vector<SDL_Point> attempt_targets;
-            attempt_targets.push_back(candidate);
+            std::vector<axis::WorldPos> attempt_targets;
+            attempt_targets.push_back(axis::from_xz(candidate, target_world.y));
             auto it_begin = tail.begin();
-            if (!tail.empty() && same_point(tail.front(), candidate)) {
+            if (!tail.empty() && same_point(axis::project_xz(tail.front()), candidate)) {
                 ++it_begin;
             }
             attempt_targets.insert(attempt_targets.end(), it_begin, tail.end());
@@ -1290,15 +1289,15 @@ bool AnimationRuntime::replan_to_destination() {
         return false;
     }
     const int visited_sq = planner_iface_->visited_thresh_ * planner_iface_->visited_thresh_;
-    if (visited_sq > 0 && animation_update::detail::distance_sq(self_->pos, planner_iface_->final_dest) <= visited_sq) {
+    if (visited_sq > 0 && animation_update::detail::distance_sq(self_->pos, axis::project_xz(planner_iface_->final_dest)) <= visited_sq) {
         return false;
     }
     mark_progress_toward_checkpoints();
-    std::vector<SDL_Point> checkpoints;
+    std::vector<axis::WorldPos> checkpoints;
     for (std::size_t i = next_checkpoint_index_; i < planner_iface_->plan_.sanitized_checkpoints.size(); ++i) {
         checkpoints.push_back(planner_iface_->plan_.sanitized_checkpoints[i]);
     }
-    if (checkpoints.empty() || !same_point(checkpoints.back(), planner_iface_->final_dest)) {
+    if (checkpoints.empty() || !same_point(axis::project_xz(checkpoints.back()), axis::project_xz(planner_iface_->final_dest))) {
         checkpoints.push_back(planner_iface_->final_dest);
     }
     auto sanitized = sanitizer_.sanitize(*self_, checkpoints, planner_iface_->visited_thresh_);
@@ -1330,9 +1329,23 @@ int AnimationRuntime::effective_grid_resolution(std::optional<int> override_reso
     return 0;
 }
 
-SDL_Point AnimationRuntime::convert_delta_to_world(SDL_Point delta, int resolution) const {
+axis::WorldPos AnimationRuntime::convert_delta_to_world(axis::WorldPos delta, int resolution) const {
     (void)resolution;
     return delta;
+}
+
+void AnimationRuntime::apply_resolved_world_position(axis::WorldPos destination, bool resort_z) {
+    if (!self_) {
+        return;
+    }
+    const SDL_Point projected = axis::project_xz(destination);
+    if (self_->pos.x == projected.x && self_->pos.y == projected.y) {
+        return;
+    }
+    self_->pos = projected;
+    if (resort_z) {
+        refresh_z_index();
+    }
 }
 
 void AnimationRuntime::refresh_z_index() {

--- a/ENGINE/animation_update/animation_runtime.hpp
+++ b/ENGINE/animation_update/animation_runtime.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <cstddef>
 #include <optional>
@@ -42,6 +42,7 @@ public:
     bool path_blocked(SDL_Point from, SDL_Point to, const Asset* ignored, std::vector<const Asset*>* blockers = nullptr) const;
     bool handle_blocked_path(SDL_Point from, SDL_Point to, const std::vector<const Asset*>& blockers);
     void refresh_z_index();
+    void apply_resolved_world_position(axis::WorldPos destination, bool resort_z);
     void mark_progress_toward_checkpoints();
     bool advance(AnimationFrame*& frame);
     void switch_to(const std::string& anim_id, std::size_t path_index = 0);
@@ -54,7 +55,7 @@ public:
 
 private:
     int        effective_grid_resolution(std::optional<int> override_resolution) const;
-    SDL_Point  convert_delta_to_world(SDL_Point delta, int resolution) const;
+    axis::WorldPos convert_delta_to_world(axis::WorldPos delta, int resolution) const;
     SDL_Point  bottom_middle(SDL_Point pos) const;
     bool       point_in_impassable(SDL_Point pt, const Asset* ignored) const;
     bool       attempt_unstick(SDL_Point from, SDL_Point to, const std::vector<const Asset*>& blockers);

--- a/ENGINE/animation_update/animation_update.cpp
+++ b/ENGINE/animation_update/animation_update.cpp
@@ -1,4 +1,4 @@
-﻿#include "animation_update.hpp"
+#include "animation_update.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -240,35 +240,48 @@ AnimationUpdate::AnimationUpdate(Asset* self, Assets* assets)
     }
 }
 
-void AnimationUpdate::auto_move(SDL_Point rel_checkpoint,
+axis::WorldPos AnimationUpdate::current_world_position() const {
+    return self_ ? axis::from_xz(self_->pos, 0) : axis::WorldPos{};
+}
+
+void AnimationUpdate::auto_move(axis::WorldPos rel_checkpoint,
                                 int visited_thresh_px,
                                 std::optional<int> checkpoint_resolution,
                                 bool override_non_locked) {
-    std::vector<SDL_Point> rel{ rel_checkpoint };
+    std::vector<axis::WorldPos> rel{ rel_checkpoint };
     auto_move(rel, visited_thresh_px, checkpoint_resolution, override_non_locked);
 }
 
-void AnimationUpdate::auto_move(Asset* target_asset,
-                                int visited_thresh_px,
-                                bool override_non_locked) {
-    if (!self_ || !target_asset) {
+void AnimationUpdate::auto_move_to(axis::WorldPos target_world,
+                                   int visited_thresh_px,
+                                   bool override_non_locked) {
+    if (!self_) {
         return;
     }
-    if (self_) {
-        self_->target_reached = false;
+    self_->target_reached = false;
+    const axis::WorldPos here = current_world_position();
+    axis::WorldPos delta{ target_world.x - here.x, target_world.y - here.y, target_world.z - here.z };
+    if (debug_enabled_) {
+        const double dx = static_cast<double>(delta.x);
+        const double dy = static_cast<double>(delta.y);
+        const double dz = static_cast<double>(delta.z);
+        std::ostringstream oss;
+        oss << "[AnimationUpdate] 3d engagement intent asset="
+            << (self_->info ? self_->info->name : std::string{"<unknown>"})
+            << " distance3d=" << std::sqrt(dx * dx + dy * dy + dz * dz)
+            << " target=(" << target_world.x << "," << target_world.y << "," << target_world.z << ")"
+            << " delta=(" << delta.x << "," << delta.y << "," << delta.z << ")";
+        vibble::log::info(oss.str());
     }
-    SDL_Point delta{ target_asset->pos.x - self_->pos.x, target_asset->pos.y - self_->pos.y };
-    if (delta.x == 0 && delta.y == 0) {
-        if (self_) {
-            self_->target_reached = true;
-            self_->needs_target = true;
-        }
+    if (delta.x == 0 && delta.y == 0 && delta.z == 0) {
+        self_->target_reached = true;
+        self_->needs_target = true;
         return;
     }
     auto_move(delta, visited_thresh_px, std::nullopt, override_non_locked);
 }
 
-void AnimationUpdate::auto_move(const std::vector<SDL_Point>& rel_checkpoints,
+void AnimationUpdate::auto_move(const std::vector<axis::WorldPos>& rel_checkpoints,
                                 int visited_thresh_px,
                                 std::optional<int> checkpoint_resolution,
                                 bool override_non_locked) {
@@ -292,33 +305,36 @@ void AnimationUpdate::auto_move(const std::vector<SDL_Point>& rel_checkpoints,
         vibble::log::info(oss.str());
     }
 
-    std::vector<SDL_Point> absolute;
+    std::vector<axis::WorldPos> absolute;
     absolute.reserve(rel_checkpoints.size());
     vibble::grid::Grid& grid_service = grid();
     SDL_Point           cursor_index = grid_service.world_to_index(self_->pos, resolution);
-    for (const SDL_Point& delta : rel_checkpoints) {
-        SDL_Point delta_indices = grid_service.convert_resolution(delta, 0, resolution);
+    int                 cursor_y = current_world_position().y;
+    for (const axis::WorldPos& delta : rel_checkpoints) {
+        SDL_Point delta_xz{ delta.x, delta.z };
+        SDL_Point delta_indices = grid_service.convert_resolution(delta_xz, 0, resolution);
         cursor_index.x += delta_indices.x;
         cursor_index.y += delta_indices.y;
+        cursor_y += delta.y;
         SDL_Point next_world = grid_service.index_to_world(cursor_index, resolution);
-        absolute.push_back(next_world);
+        absolute.push_back(axis::from_xz(next_world, cursor_y));
     }
 
     plan_      = planner_(*self_, sanitizer_.sanitize(*self_, absolute, visited_thresh_), visited_thresh_, grid());
     final_dest = plan_.final_dest;
-    plan_.world_start = self_->pos;
+    plan_.world_start = current_world_position();
     plan_.override_non_locked = override_non_locked;
     if (debug_logging) {
         std::ostringstream oss;
         oss << "[AnimationUpdate] auto_move plan asset=" << asset_name
-            << " final_dest=(" << final_dest.x << "," << final_dest.y << ")"
+            << " final_dest=(" << final_dest.x << "," << final_dest.y << "," << final_dest.z << ")"
             << " sanitized_points=" << plan_.sanitized_checkpoints.size() << " strides=" << plan_.strides.size();
         vibble::log::info(oss.str());
     }
 
     if (plan_.strides.empty()) {
         if (debug_logging) {
-            vibble::log::info("[AnimationUpdate] auto_move plan produced no strides for asset=" + asset_name);
+            vibble::log::info("[AnimationUpdate] auto_move plan produced no strides for asset=" + asset_name + " reason=empty_or_stuck_3d_plan");
         }
         if (self_) {
             self_->needs_target = true;
@@ -336,7 +352,7 @@ void AnimationUpdate::auto_move(const std::vector<SDL_Point>& rel_checkpoints,
     }
 }
 
-void AnimationUpdate::move(SDL_Point delta,
+void AnimationUpdate::move(axis::WorldPos delta,
                            const std::string& animation,
                            bool               resort_z,
                            bool               override_non_locked) {
@@ -357,7 +373,7 @@ void AnimationUpdate::clear_movement_plan() {
     const bool debug_logging = debug_enabled_;
     plan_.strides.clear();
     plan_.sanitized_checkpoints.clear();
-    plan_.final_dest = self_ ? self_->pos : SDL_Point{ 0, 0 };
+    plan_.final_dest = self_ ? current_world_position() : axis::WorldPos{};
     plan_.override_non_locked = true;
     final_dest       = plan_.final_dest;
     input_event_     = true;
@@ -365,7 +381,7 @@ void AnimationUpdate::clear_movement_plan() {
     if (debug_logging) {
         std::ostringstream oss;
         oss << "[AnimationUpdate] clear_movement_plan asset=" << asset_name
-            << " final_dest=(" << final_dest.x << "," << final_dest.y << ")";
+            << " final_dest=(" << final_dest.x << "," << final_dest.y << "," << final_dest.z << ")";
         vibble::log::info(oss.str());
     }
 
@@ -379,7 +395,7 @@ void AnimationUpdate::clear_movement_plan() {
 
 void AnimationUpdate::cancel_all_movement() {
     clear_movement_plan();
-    move(SDL_Point{0, 0}, animation_update::detail::kDefaultAnimation, true, true);
+    move(axis::WorldPos{}, animation_update::detail::kDefaultAnimation, true, true);
 }
 
 std::size_t AnimationUpdate::path_index_for(const std::string& anim_id) const {

--- a/ENGINE/animation_update/animation_update.hpp
+++ b/ENGINE/animation_update/animation_update.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <optional>
 #include <string>
@@ -68,13 +68,13 @@ public:
     void set_debug_enabled(bool enabled);
     bool debug_enabled() const;
 
-    void auto_move(const std::vector<SDL_Point>& rel_checkpoints, int visited_thresh_px, std::optional<int> checkpoint_resolution = std::nullopt, bool override_non_locked = true);
-    void auto_move(SDL_Point rel_checkpoint, int visited_thresh_px = 0, std::optional<int> checkpoint_resolution = std::nullopt, bool override_non_locked = true);
-    void auto_move(Asset* target_asset, int visited_thresh_px = 0, bool override_non_locked = true);
+    void auto_move(const std::vector<axis::WorldPos>& rel_checkpoints, int visited_thresh_px, std::optional<int> checkpoint_resolution = std::nullopt, bool override_non_locked = true);
+    void auto_move(axis::WorldPos rel_checkpoint, int visited_thresh_px = 0, std::optional<int> checkpoint_resolution = std::nullopt, bool override_non_locked = true);
+    void auto_move_to(axis::WorldPos target_world, int visited_thresh_px = 0, bool override_non_locked = true);
 
     int visit_threshold_px() const { return visited_thresh_; }
 
-    void move(SDL_Point delta, const std::string& animation, bool               resort_z            = true, bool               override_non_locked = true);
+    void move(axis::WorldPos delta, const std::string& animation, bool               resort_z            = true, bool               override_non_locked = true);
 
     void set_animation(const std::string& animation_id);
 
@@ -82,13 +82,15 @@ public:
 
     const Plan* current_plan() const { return &plan_; }
 
+    axis::WorldPos current_world_position() const;
+
     void cancel_all_movement();
 
 private:
 
     bool has_pending_move() const { return move_pending_; }
     struct MoveRequest {
-        SDL_Point    delta{0, 0};
+        axis::WorldPos delta{};
         std::string  animation_id;
         bool         resort_z = true;
         bool         override_non_locked = true;
@@ -106,7 +108,7 @@ private:
     void clear_movement_plan();
     std::size_t path_index_for(const std::string& anim_id) const;
     AnimationPlayer& player() { return player_; }
-    SDL_Point final_dest{0, 0};
+    axis::WorldPos final_dest{};
 
     AnimationPlayer player_{};
 

--- a/ENGINE/animation_update/custom_controllers/Bartender_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Bartender_controller.cpp
@@ -23,7 +23,7 @@ void BartenderController::init() {
 
     auto it = self_->info->animations.find(default_anim);
     if (it != self_->info->animations.end() && !it->second.frames.empty()) {
-        self_->anim_->move(SDL_Point{0, 0}, default_anim);
+        self_->anim_->move(axis::WorldPos{}, default_anim);
     }
 }
 

--- a/ENGINE/animation_update/custom_controllers/Bomb_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Bomb_controller.cpp
@@ -1,4 +1,5 @@
-﻿#include "Bomb_controller.hpp"
+#include "Bomb_controller.hpp"
+#include "animation_update/custom_controllers/controller_path_utils.hpp"
 #include "asset/Asset.hpp"
 #include "core/AssetsManager.hpp"
 
@@ -28,6 +29,6 @@ void BombController::update(const Input&) {
         }
     }
     else if (self_->needs_target) {
-        self_->anim_->auto_move(player);
+        self_->anim_->auto_move_to(controller_paths::engagement_point(self_, player, 28, 18, 48));
     }
 }

--- a/ENGINE/animation_update/custom_controllers/Carrie_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Carrie_controller.cpp
@@ -23,7 +23,7 @@ void CarrieController::init() {
 
     auto it = self_->info->animations.find(default_anim);
     if (it != self_->info->animations.end() && !it->second.frames.empty()) {
-        self_->anim_->move(SDL_Point{0, 0}, default_anim);
+        self_->anim_->move(axis::WorldPos{}, default_anim);
     }
 }
 

--- a/ENGINE/animation_update/custom_controllers/Davey_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Davey_controller.cpp
@@ -1,4 +1,5 @@
 #include "Davey_controller.hpp"
+#include "animation_update/custom_controllers/controller_path_utils.hpp"
 #include "asset/Asset.hpp"
 #include "core/AssetsManager.hpp"
 
@@ -20,5 +21,5 @@ void DaveyController::update(const Input&) {
         return;
     }
 
-    self_->anim_->auto_move(player);
+    self_->anim_->auto_move_to(controller_paths::engagement_point(self_, player, 28, 18, 48));
 }

--- a/ENGINE/animation_update/custom_controllers/Frog_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Frog_controller.cpp
@@ -40,5 +40,5 @@ void FrogController::update(const Input&) {
         return;
     }
 
-    self_->anim_->auto_move(player);
+    self_->anim_->auto_move_to(controller_paths::engagement_point(self_, player, 28, 18, 48));
 }

--- a/ENGINE/animation_update/custom_controllers/Gary_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Gary_controller.cpp
@@ -23,7 +23,7 @@ void GaryController::init() {
 
     auto it = self_->info->animations.find(default_anim);
     if (it != self_->info->animations.end() && !it->second.frames.empty()) {
-        self_->anim_->move(SDL_Point{0, 0}, default_anim);
+        self_->anim_->move(axis::WorldPos{}, default_anim);
     }
 }
 

--- a/ENGINE/animation_update/custom_controllers/Vibble_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/Vibble_controller.cpp
@@ -1,4 +1,4 @@
-﻿#include "Vibble_controller.hpp"
+#include "Vibble_controller.hpp"
 
 #include "animation_update/animation_update.hpp"
 #include "asset/Asset.hpp"
@@ -32,7 +32,7 @@ void VibbleController::movement(const Input& input) {
     if (raw_x == 0 && raw_y == 0) {
         subpixel_x_ = 0.0f;
         subpixel_y_ = 0.0f;
-        player_->anim_->move(SDL_Point{ 0, 0 }, animation_update::detail::kDefaultAnimation);
+        player_->anim_->move(axis::WorldPos{}, animation_update::detail::kDefaultAnimation);
         return;
     }
 
@@ -82,7 +82,7 @@ void VibbleController::movement(const Input& input) {
         }
     }
 
-    player_->anim_->move(SDL_Point{ dx_, dy_ }, animation_id);
+    player_->anim_->move(axis::WorldPos{ dx_, 0, dy_ }, animation_id);
 
 }
 

--- a/ENGINE/animation_update/custom_controllers/controller_path_utils.hpp
+++ b/ENGINE/animation_update/custom_controllers/controller_path_utils.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <SDL.h>
 
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "asset/Asset.hpp"
+#include "animation_update/stride_types.hpp"
 
 namespace controller_paths {
 
@@ -55,20 +56,20 @@ inline SDL_Point clamp_delta(SDL_Point delta, int radius) {
     return SDL_Point{ clamped.x, clamped.y };
 }
 
-inline std::vector<SDL_Point> to_relative(const SDL_Point& origin, const std::vector<SDL_Point>& absolute_points) {
-    std::vector<SDL_Point> result;
+inline std::vector<axis::WorldPos> to_relative(const SDL_Point& origin, const std::vector<SDL_Point>& absolute_points) {
+    std::vector<axis::WorldPos> result;
     result.reserve(absolute_points.size());
     SDL_Point cursor = origin;
     for (const SDL_Point& pt : absolute_points) {
         SDL_Point delta{ pt.x - cursor.x, pt.y - cursor.y };
-        result.push_back(delta);
+        result.push_back(axis::from_xz(delta, 0));
         cursor = pt;
     }
     return result;
 }
 
-inline std::vector<SDL_Point> idle_path(const Asset* asset, int rest_ratio) {
-    std::vector<SDL_Point> relative;
+inline std::vector<axis::WorldPos> idle_path(const Asset* asset, int rest_ratio) {
+    std::vector<axis::WorldPos> relative;
     if (!asset) {
         return relative;
     }
@@ -76,7 +77,7 @@ inline std::vector<SDL_Point> idle_path(const Asset* asset, int rest_ratio) {
     const SDL_Point origin = asset->pos;
     const int       radius = neighbor_radius(asset);
     if (radius <= 0) {
-        relative.push_back(SDL_Point{ 0, 0 });
+        relative.push_back(axis::WorldPos{});
         return relative;
     }
 
@@ -93,8 +94,8 @@ inline std::vector<SDL_Point> idle_path(const Asset* asset, int rest_ratio) {
     return to_relative(origin, absolute);
 }
 
-inline std::vector<SDL_Point> pursue_path(const Asset* asset, const Asset* target) {
-    std::vector<SDL_Point> relative;
+inline std::vector<axis::WorldPos> pursue_path(const Asset* asset, const Asset* target) {
+    std::vector<axis::WorldPos> relative;
     if (!asset || !target) {
         return relative;
     }
@@ -103,13 +104,13 @@ inline std::vector<SDL_Point> pursue_path(const Asset* asset, const Asset* targe
     const int       radius = neighbor_radius(asset);
 
     SDL_Point desired = clamp_to_radius(origin, target->pos, radius);
-    relative.push_back(SDL_Point{ desired.x - origin.x, desired.y - origin.y });
+    relative.push_back(axis::WorldPos{ desired.x - origin.x, 0, desired.y - origin.y });
 
     return relative;
 }
 
-inline std::vector<SDL_Point> flee_path(const Asset* asset, const Asset* threat) {
-    std::vector<SDL_Point> relative;
+inline std::vector<axis::WorldPos> flee_path(const Asset* asset, const Asset* threat) {
+    std::vector<axis::WorldPos> relative;
     if (!asset) {
         return relative;
     }
@@ -117,7 +118,7 @@ inline std::vector<SDL_Point> flee_path(const Asset* asset, const Asset* threat)
     const SDL_Point origin = asset->pos;
     const int       radius = neighbor_radius(asset);
     if (radius <= 0) {
-        relative.push_back(SDL_Point{ 0, 0 });
+        relative.push_back(axis::WorldPos{});
         return relative;
     }
 
@@ -136,12 +137,12 @@ inline std::vector<SDL_Point> flee_path(const Asset* asset, const Asset* threat)
                        origin.y + static_cast<int>(std::round(direction.y * scale)) };
 
     desired = clamp_to_radius(origin, desired, radius);
-    relative.push_back(SDL_Point{ desired.x - origin.x, desired.y - origin.y });
+    relative.push_back(axis::WorldPos{ desired.x - origin.x, 0, desired.y - origin.y });
 
     return relative;
 }
 
-inline std::vector<SDL_Point> orbit_path(const Asset* asset, const Asset* center, int radius, int steps = 8) {
+inline std::vector<axis::WorldPos> orbit_path(const Asset* asset, const Asset* center, int radius, int steps = 8) {
     if (!asset || !center) {
         return {};
     }
@@ -184,6 +185,39 @@ inline std::vector<SDL_Point> orbit_path(const Asset* asset, const Asset* center
     }
 
     return to_relative(origin, absolute);
+}
+
+inline axis::WorldPos engagement_point(const Asset* asset,
+                                       const Asset* target,
+                                       int desired_range,
+                                       int min_approach_range,
+                                       int max_approach_range) {
+    if (!asset || !target) {
+        return axis::WorldPos{};
+    }
+
+    const SDL_Point self_pos = asset->pos;
+    const SDL_Point target_pos = target->pos;
+    double dx = static_cast<double>(self_pos.x - target_pos.x);
+    double dz = static_cast<double>(self_pos.y - target_pos.y);
+    double distance = std::sqrt(dx * dx + dz * dz);
+    if (distance <= 1e-6) {
+        dx = 1.0;
+        dz = 0.0;
+        distance = 1.0;
+    }
+
+    const int radius_limit = neighbor_radius(asset);
+    const int clamped_desired = std::clamp(desired_range,
+                                           std::max(0, min_approach_range),
+                                           std::max(min_approach_range, max_approach_range));
+    const double inv = 1.0 / distance;
+    SDL_Point desired{ target_pos.x + static_cast<int>(std::round(dx * inv * clamped_desired)),
+                       target_pos.y + static_cast<int>(std::round(dz * inv * clamped_desired)) };
+    if (radius_limit > 0) {
+        desired = clamp_to_radius(self_pos, desired, radius_limit);
+    }
+    return axis::from_xz(desired, 0);
 }
 
 inline int default_visit_threshold(const Asset* asset) {

--- a/ENGINE/animation_update/custom_controllers/controller_visit_threshold.hpp
+++ b/ENGINE/animation_update/custom_controllers/controller_visit_threshold.hpp
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include <algorithm>
 #include <cmath>
@@ -10,7 +10,7 @@ class Asset;
 
 namespace controller_utils {
 
-inline int controller_visit_threshold(const Asset* asset, const std::vector<SDL_Point>& planned_path) {
+inline int controller_visit_threshold(const Asset* asset, const std::vector<axis::WorldPos>& planned_path) {
     if (!asset) {
         return 0;
     }
@@ -22,9 +22,9 @@ inline int controller_visit_threshold(const Asset* asset, const std::vector<SDL_
     const int base_threshold = std::max(0, controller_paths::default_visit_threshold(asset));
 
     long long max_step_sq = 0;
-    for (const SDL_Point& step : planned_path) {
+    for (const axis::WorldPos& step : planned_path) {
         const long long dx = static_cast<long long>(step.x);
-        const long long dy = static_cast<long long>(step.y);
+        const long long dy = static_cast<long long>(step.z);
         const long long step_sq = dx * dx + dy * dy;
         if (step_sq > max_step_sq) {
             max_step_sq = step_sq;

--- a/ENGINE/animation_update/custom_controllers/default_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/default_controller.cpp
@@ -1,4 +1,4 @@
-﻿#include "default_controller.hpp"
+#include "default_controller.hpp"
 #include "asset/Asset.hpp"
 #include "asset/animation.hpp"
 #include "asset/asset_info.hpp"
@@ -22,7 +22,7 @@ void DefaultController::update(const Input& ) {
     }
 
     if (self_->current_animation != default_anim || self_->current_frame == nullptr) {
-        self_->anim_->move(SDL_Point{ 0, 0 }, default_anim);
+        self_->anim_->move(axis::WorldPos{}, default_anim);
         return;
     }
 

--- a/ENGINE/animation_update/custom_controllers/spider_controller.cpp
+++ b/ENGINE/animation_update/custom_controllers/spider_controller.cpp
@@ -1,4 +1,5 @@
 #include "spider_controller.hpp"
+#include "animation_update/custom_controllers/controller_path_utils.hpp"
 #include "asset/Asset.hpp"
 #include "core/AssetsManager.hpp"
 
@@ -28,6 +29,6 @@ void spiderController::update(const Input&) {
         }
     }
     else if (self_->needs_target) {
-        self_->anim_->auto_move(player);
+        self_->anim_->auto_move_to(controller_paths::engagement_point(self_, player, 28, 18, 48));
     }
 }

--- a/ENGINE/animation_update/get_best_path.cpp
+++ b/ENGINE/animation_update/get_best_path.cpp
@@ -149,14 +149,15 @@ struct SmallestStride {
 }
 
 Plan GetBestPath::operator()(const Asset& self,
-                             const std::vector<SDL_Point>& sanitized_checkpoints,
+                             const std::vector<axis::WorldPos>& sanitized_checkpoints,
                              int visited_thresh_px,
                              const vibble::grid::Grid& grid) const {
     Plan plan;
     plan.sanitized_checkpoints = sanitized_checkpoints;
 
     SDL_Point cursor = self.pos;
-    plan.final_dest  = cursor;
+    int cursor_y = 0;
+    plan.final_dest  = axis::from_xz(cursor, cursor_y);
 
     if (!self.info) {
         return plan;
@@ -185,7 +186,8 @@ Plan GetBestPath::operator()(const Asset& self,
     }
 
     bool aborted = false;
-    for (const SDL_Point& checkpoint : sanitized_checkpoints) {
+    for (const axis::WorldPos& checkpoint_world : sanitized_checkpoints) {
+        SDL_Point checkpoint = axis::project_xz(checkpoint_world);
         if (visited_sq > 0 && animation_update::detail::distance_sq(cursor, checkpoint) <= visited_sq) {
             continue;
         }
@@ -269,7 +271,8 @@ Plan GetBestPath::operator()(const Asset& self,
                     if (fallback_dist_sq < current_dist_sq) {
                         plan.strides.push_back(Stride{ min_stride.anim_id, 1, min_stride.path_index });
                         cursor = fallback_next;
-                        plan.final_dest = cursor;
+                        cursor_y = checkpoint_world.y;
+                        plan.final_dest = axis::from_xz(cursor, cursor_y);
                     } else {
                         aborted = true;
                         break;
@@ -281,7 +284,8 @@ Plan GetBestPath::operator()(const Asset& self,
             } else {
                 plan.strides.push_back(Stride{ best.animation_id, best.frames, best.path_index });
                 cursor = best.end_position;
-                plan.final_dest = cursor;
+                cursor_y = checkpoint_world.y;
+                plan.final_dest = axis::from_xz(cursor, cursor_y);
             }
 
             if (++safeguard > 256) {

--- a/ENGINE/animation_update/get_best_path.hpp
+++ b/ENGINE/animation_update/get_best_path.hpp
@@ -11,5 +11,5 @@ class Asset;
 
 class GetBestPath {
 public:
-    Plan operator()(const Asset& self, const std::vector<SDL_Point>& sanitized_checkpoints, int visited_thresh_px, const vibble::grid::Grid& grid) const;
+    Plan operator()(const Asset& self, const std::vector<axis::WorldPos>& sanitized_checkpoints, int visited_thresh_px, const vibble::grid::Grid& grid) const;
 };

--- a/ENGINE/animation_update/movement_plan_executor.cpp
+++ b/ENGINE/animation_update/movement_plan_executor.cpp
@@ -19,7 +19,7 @@ bool MovementPlanExecutor::tick(AnimationRuntime& up, Plan& plan,
         if (self && up.planner_iface_) {
             const int visited_thresh = up.planner_iface_->visit_threshold_px();
             const int visited_thresh_squared = visited_thresh * visited_thresh;
-            const int dist_sq = (self->pos.x - plan.final_dest.x) * (self->pos.x - plan.final_dest.x) + (self->pos.y - plan.final_dest.y) * (self->pos.y - plan.final_dest.y);
+            const int dist_sq = (self->pos.x - plan.final_dest.x) * (self->pos.x - plan.final_dest.x) + (self->pos.y - plan.final_dest.z) * (self->pos.y - plan.final_dest.z);
             if (dist_sq <= visited_thresh_squared) {
                 self->target_reached = true;
             }
@@ -37,7 +37,7 @@ bool MovementPlanExecutor::tick(AnimationRuntime& up, Plan& plan,
     auto abort_plan = [&]() {
         plan.strides.clear();
         plan.sanitized_checkpoints.clear();
-        plan.final_dest = self->pos;
+        plan.final_dest = axis::from_xz(self->pos, plan.final_dest.y);
         stride_index    = 0;
         stride_frame_counter = 0;
         up.switch_to(animation_update::detail::kDefaultAnimation, 0);
@@ -104,10 +104,7 @@ bool MovementPlanExecutor::tick(AnimationRuntime& up, Plan& plan,
     }
 
     if (delta.x != 0 || delta.y != 0) {
-        self->pos = to;
-        if (!frame || frame->z_resort) {
-            up.refresh_z_index();
-        }
+        up.apply_resolved_world_position(axis::from_xz(to, plan.final_dest.y), !frame || frame->z_resort);
         up.mark_progress_toward_checkpoints();
     }
 

--- a/ENGINE/animation_update/path_sanitizer.cpp
+++ b/ENGINE/animation_update/path_sanitizer.cpp
@@ -104,37 +104,39 @@ static SDL_Point walk_back_to_perimeter(SDL_Point start,
     return best;
 }
 
-std::vector<SDL_Point> PathSanitizer::sanitize(const Asset& self,
-                                               const std::vector<SDL_Point>& absolute_checkpoints,
+std::vector<axis::WorldPos> PathSanitizer::sanitize(const Asset& self,
+                                               const std::vector<axis::WorldPos>& absolute_checkpoints,
                                                int visited_thresh_px) const {
-    std::vector<SDL_Point> sanitized;
+    std::vector<axis::WorldPos> sanitized;
     if (absolute_checkpoints.empty()) {
         return sanitized;
     }
 
     const auto collision_areas = gather_collision_areas(self);
-    const SDL_Point origin     = self.pos;
+    const axis::WorldPos origin = axis::from_xz(self.pos, 0);
     const int       thresh_sq  = visited_thresh_px * visited_thresh_px;
     const Assets*   assets     = self.get_assets();
 
-    for (const SDL_Point& checkpoint : absolute_checkpoints) {
-        SDL_Point anchor = sanitized.empty() ? origin : sanitized.back();
-        if (thresh_sq > 0 && animation_update::detail::distance_sq(anchor, checkpoint) <= thresh_sq) {
+    for (const axis::WorldPos& checkpoint : absolute_checkpoints) {
+        axis::WorldPos anchor = sanitized.empty() ? origin : sanitized.back();
+        SDL_Point anchor_xz = axis::project_xz(anchor);
+        SDL_Point checkpoint_xz = axis::project_xz(checkpoint);
+        if (thresh_sq > 0 && animation_update::detail::distance_sq(anchor_xz, checkpoint_xz) <= thresh_sq) {
             continue;
         }
 
-        SDL_Point candidate = checkpoint;
+        SDL_Point candidate = checkpoint_xz;
         for (const auto& entry : collision_areas) {
             if (entry.area.contains_point(candidate)) {
                 candidate = nudge_outside(candidate, entry.area);
             }
         }
 
-        if (segment_hits_any(anchor, candidate, collision_areas)) {
-            candidate = walk_back_to_perimeter(anchor, candidate, collision_areas);
+        if (segment_hits_any(anchor_xz, candidate, collision_areas)) {
+            candidate = walk_back_to_perimeter(anchor_xz, candidate, collision_areas);
         }
 
-        const SDL_Point anchor_bottom    = animation_update::detail::bottom_middle_for(self, anchor);
+        const SDL_Point anchor_bottom    = animation_update::detail::bottom_middle_for(self, anchor_xz);
         const SDL_Point candidate_bottom = animation_update::detail::bottom_middle_for(self, candidate);
         if (!animation_update::detail::bottom_point_inside_playable_area(assets, candidate_bottom)) {
             continue;
@@ -143,11 +145,11 @@ std::vector<SDL_Point> PathSanitizer::sanitize(const Asset& self,
             continue;
         }
 
-        if (thresh_sq > 0 && animation_update::detail::distance_sq(anchor, candidate) <= thresh_sq) {
+        if (thresh_sq > 0 && animation_update::detail::distance_sq(anchor_xz, candidate) <= thresh_sq) {
             continue;
         }
 
-        sanitized.push_back(candidate);
+        sanitized.push_back(axis::from_xz(candidate, checkpoint.y));
     }
 
     return sanitized;

--- a/ENGINE/animation_update/path_sanitizer.hpp
+++ b/ENGINE/animation_update/path_sanitizer.hpp
@@ -4,9 +4,11 @@
 
 #include <SDL.h>
 
+#include "stride_types.hpp"
+
 class Asset;
 
 class PathSanitizer {
 public:
-    std::vector<SDL_Point> sanitize(const Asset& self, const std::vector<SDL_Point>& absolute_checkpoints, int visited_thresh_px) const;
+    std::vector<axis::WorldPos> sanitize(const Asset& self, const std::vector<axis::WorldPos>& absolute_checkpoints, int visited_thresh_px) const;
 };

--- a/ENGINE/animation_update/stride_types.hpp
+++ b/ENGINE/animation_update/stride_types.hpp
@@ -6,6 +6,28 @@
 
 #include <SDL.h>
 
+namespace axis {
+
+struct WorldPos {
+    int x = 0;
+    int y = 0;
+    int z = 0;
+};
+
+inline WorldPos make_world_pos(int x, int y, int z) {
+    return WorldPos{ x, y, z };
+}
+
+inline SDL_Point project_xz(WorldPos pos) {
+    return SDL_Point{ pos.x, pos.z };
+}
+
+inline WorldPos from_xz(SDL_Point point, int world_y = 0) {
+    return WorldPos{ point.x, world_y, point.y };
+}
+
+} // namespace axis
+
 struct Stride {
     std::string animation_id;
     int         frames = 0;
@@ -13,9 +35,9 @@ struct Stride {
 };
 
 struct Plan {
-    std::vector<SDL_Point> sanitized_checkpoints;
+    std::vector<axis::WorldPos> sanitized_checkpoints;
     std::vector<Stride>    strides;
-    SDL_Point              final_dest{0, 0};
-    SDL_Point              world_start{0, 0};
+    axis::WorldPos         final_dest{};
+    axis::WorldPos         world_start{};
     bool                   override_non_locked = true;
 };

--- a/ENGINE/asset/Asset.cpp
+++ b/ENGINE/asset/Asset.cpp
@@ -468,7 +468,7 @@ void Asset::update() {
             if (def == info->animations.end()) def = info->animations.begin();
             if (def != info->animations.end()) {
                 if (anim_) {
-                    anim_->move(SDL_Point{ 0, 0 }, def->first);
+                    anim_->move(axis::WorldPos{}, def->first);
                 } else {
                     current_animation = def->first;
                     Animation& anim   = def->second;


### PR DESCRIPTION
### Motivation
- Replace the legacy 2D movement/attack path with a single 3D movement intent pipeline so chase, attack startup, knockback, root motion and direct moves all resolve to one 3D world output per tick.
- Preserve vertical (`y`) information and compute engagement points around targets instead of chasing raw X/Z centers.

### Description
- Introduced `axis::WorldPos` and migrated planning state and public movement APIs from `SDL_Point` to `axis::WorldPos` (`Plan`, `Stride` checkpoints, `plan.final_dest`, `AnimationUpdate` `auto_move`/`auto_move_to`/`move`, and related types). (`ENGINE/animation_update/stride_types.hpp`, `ENGINE/animation_update/animation_update.*`)
- Path sanitization and pathfinding now accept/return 3D checkpoints and preserve the authored/runtime Y when producing sanitized checkpoints; X/Z are projected for collision/playable-area tests. (`PathSanitizer`, `GetBestPath`, `ENGINE/animation_update/path_sanitizer.*`, `ENGINE/animation_update/get_best_path.*`)
- Unified movement application so frame/root-motion/direct-move execution resolves into one final world write via `AnimationRuntime::apply_resolved_world_position`, which projects X/Z into `Asset::pos` only at the final write and respects `y` for plan intent. (`ENGINE/animation_update/animation_runtime.*`, `ENGINE/animation_update/movement_plan_executor.cpp`)
- Migrated custom controllers and helper utilities to emit 3D intents and added an `engagement_point` helper that computes an approach point around targets (used by Davey/Frog/Bomb/spider controllers and controller helpers). Controller visit-thresholds and path utilities were updated to consume `axis::WorldPos`. (`ENGINE/animation_update/custom_controllers/*`, `controller_path_utils.hpp`, `controller_visit_threshold.hpp`)
- Added focused debug logging for 3D engagement intents and plan reasons (distance, target, delta, final destination, sanitized checkpoint counts, and empty/stuck plan reasons). (`ENGINE/animation_update/animation_update.cpp`)
- Updated fallback/default movement uses to call the new 3D APIs (e.g., asset animation startup and player movement). (`ENGINE/asset/Asset.cpp`, various controller files)

### Testing
- Ran `git diff --check` to validate whitespace/patch consistency and it completed with no reported issues.
- No builds or automated test suites were executed per instructions; full build and runtime tests are recommended to validate behavior in-engine (movement, attack startup, runtime active-frame attack boxes, and controller re-engagement).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196e8c50ac832f8e13fdadfb562e41)