### PR TITLE
Use single asset scale variant

### DIFF
--- a/ENGINE/asset/animation_loader.cpp
+++ b/ENGINE/asset/animation_loader.cpp
@@ -898,22 +898,36 @@ void AnimationLoader::load(Animation& animation,
                                 break;
                         }
 
+                        const auto optional_sequence_present = [](const std::string& folder) {
+                                std::error_code ec;
+                                return fs::exists(fs::path(folder) / "0.png", ec) && !ec;
+                        };
+
                         std::vector<SDL_Surface*> fg_loaded;
-                        if (CacheManager::load_surface_sequence(paths.foreground_folder, frame_count, fg_loaded) &&
+                        if (optional_sequence_present(paths.foreground_folder) &&
+                            CacheManager::load_surface_sequence(paths.foreground_folder, frame_count, fg_loaded) &&
                             static_cast<int>(fg_loaded.size()) == frame_count) {
                                 foreground_surfaces[idx] = std::move(fg_loaded);
                         }
 
                         std::vector<SDL_Surface*> bg_loaded;
-                        if (CacheManager::load_surface_sequence(paths.background_folder, frame_count, bg_loaded) &&
+                        if (optional_sequence_present(paths.background_folder) &&
+                            CacheManager::load_surface_sequence(paths.background_folder, frame_count, bg_loaded) &&
                             static_cast<int>(bg_loaded.size()) == frame_count) {
                                 background_surfaces[idx] = std::move(bg_loaded);
                         }
 
                         std::vector<SDL_Surface*> mask_loaded;
-                        if (CacheManager::load_surface_sequence(paths.mask_folder, frame_count, mask_loaded) &&
-                            static_cast<int>(mask_loaded.size()) == frame_count) {
-                                mask_surfaces[idx] = std::move(mask_loaded);
+                        if (optional_sequence_present(paths.mask_folder)) {
+                                if (CacheManager::load_surface_sequence(paths.mask_folder, frame_count, mask_loaded) &&
+                                    static_cast<int>(mask_loaded.size()) == frame_count) {
+                                        mask_surfaces[idx] = std::move(mask_loaded);
+                                } else if (needs_masks) {
+                                        all_surfaces_loaded = false;
+                                        std::cout << "[AnimationLoader] " << info.name << "::" << trigger
+                                                  << " failed to load masks for variant " << idx << " at " << paths.mask_folder << "\n";
+                                        break;
+                                }
                         } else if (needs_masks) {
                                 all_surfaces_loaded = false;
                                 std::cout << "[AnimationLoader] " << info.name << "::" << trigger

--- a/ENGINE/render/scaling_logic.hpp
+++ b/ENGINE/render/scaling_logic.hpp
@@ -91,14 +91,15 @@ struct ScalingLogic {
         bool has_custom_steps() const { return !steps.empty(); }
 };
 
-    static constexpr ::std::size_t kMaxVariantCount     = 5;
+    static constexpr ::std::size_t kMaxVariantCount     = 1;
     static constexpr ::std::size_t kDefaultVariantCount = kMaxVariantCount;
     static inline const ScaleSteps& DefaultScaleSteps() {
-        static const ScaleSteps kDefaultSteps = {1.00f, 0.75f, 0.50f, 0.25f, 0.10f};
+        static const ScaleSteps kDefaultSteps = {1.00f};
         return kDefaultSteps;
     }
 
     static inline void NormalizeVariantSteps(ScaleSteps& steps) {
+        steps.clear();
         const auto& defaults = DefaultScaleSteps();
         steps.assign(defaults.begin(), defaults.end());
     }

--- a/ENGINE/render_pipeline/ScalingProfileBuilder.cpp
+++ b/ENGINE/render_pipeline/ScalingProfileBuilder.cpp
@@ -234,7 +234,7 @@ std::string iso_timestamp_now() {
 
 bool BuildScalingProfiles(const ScalingProfileBuildOptions& options) {
     (void)options;
-    vibble::log::info("[ScalingProfileBuilder] Dynamic scaling profiles disabled; using fixed variants (100/75/50/25/10).");
+    vibble::log::info("[ScalingProfileBuilder] Dynamic scaling profiles disabled; using single fixed variant (100).");
     return true;
 #if 0
     const double aspect = (options.screen_aspect > 0.0) ? options.screen_aspect : kDefaultAspect;

--- a/tools/asset_tool.py
+++ b/tools/asset_tool.py
@@ -21,8 +21,10 @@ from shadow_mask import ShadowMaskGenerator, ShadowMaskSettings
 
 
 def normalize_variant_steps(steps):
-    # Always use fixed variants: 100%, 75%, 50%, 25%, 10%.
-    return [1.0, 0.75, 0.5, 0.25, 0.1]
+    # The runtime now loads a single prebuilt size variant and applies any
+    # remaining scale adjustment at render time. Keep the asset pipeline in
+    # lockstep so rebuilt caches only contain scale_100.
+    return [1.0]
 
 
 def _configure_logger() -> logging.Logger:
@@ -291,7 +293,8 @@ class AssetTool:
         self.executor = ProcessPoolExecutor(max_workers=self.max_workers)
 
     def get_normalized_steps_for_asset(self, asset_name):
-        # Manifest-driven scaling profiles are disabled; always use fixed variants.
+        # Manifest-driven scaling profiles are disabled; always use the single
+        # runtime variant.
         return normalize_variant_steps([])
 
     def load_manifest(self) -> Dict:


### PR DESCRIPTION
### Motivation
- The runtime and asset pipeline diverged after switching to a single prebuilt variant, causing the game to try to load non-existent `scale_75/50/25/10` cache folders and produce many asset load failures. 
- The change aligns the loader and asset pipeline so the game loads the single `scale_100` variant reliably and treats optional variant layers (foreground/background/mask) correctly.

### Description
- Set the engine to use a single variant by default by changing `render_pipeline::ScalingLogic::DefaultScaleSteps()` and `kMaxVariantCount` to only include `1.00` and adjusting `NormalizeVariantSteps` in `ENGINE/render/scaling_logic.hpp`.
- Update the asset rebuild tool to produce only the runtime variant (`scale_100`) by returning `[1.0]` from `normalize_variant_steps` in `tools/asset_tool.py` and by using that single-variant policy in `get_normalized_steps_for_asset`.
- Make optional foreground/background/mask sequences truly optional in `ENGINE/asset/animation_loader.cpp` by checking whether a `0.png` exists before attempting to load a sequence, while still failing when shaded assets require masks (`needs_masks`).
- Adjust a log message in `ENGINE/render_pipeline/ScalingProfileBuilder.cpp` to reflect the single-variant behavior and avoid misleading wording.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues; the check succeeded.
- No builds or automated tests were executed per the instruction not to run tests or builds.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19712de1d0832f81e9d22a383fceab)